### PR TITLE
Updated description of NetworkName

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -72,7 +72,8 @@ type BlockDevice struct {
 	// The ID of the instance to which the device is connected.
 	InstanceID *InstanceID `json:"instanceID"`
 
-	// The name of the network on which the device resides.
+	// The name the device is known by in order to discover
+	// locally.
 	NetworkName string `json:"networkName"`
 
 	// The name of the provider that owns the block device.


### PR DESCRIPTION
The description now repesents the real usage for the parameter.
It is used when a storage platform is advertising a device to
a networked host.  The networked host needs to a hint or name
that it can use to properly discover the device being advertised.