### PR TITLE
Changed URL pattern for servers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -188,7 +188,7 @@ func Dial(
 		return nil, goof.WithField("netProto", netProto, "tcp protocol only")
 	}
 
-	c.url = fmt.Sprintf("http://%s/libStorage/%s", laddr, serverName)
+	c.url = fmt.Sprintf("http://%s/libStorage/servers/%s", laddr, serverName)
 	log.WithField("url", c.url).Debug("got libStorage service URL")
 
 	if err := c.initClientTool(ctx); err != nil {

--- a/service/server/server.go
+++ b/service/server/server.go
@@ -61,7 +61,8 @@ func Serve(
 			serviceInfo[name].server.ServeHTTP(w, req)
 		})
 	loggingHandler := handlers.NewLoggingHandler(httpHandler, config)
-	r.Handle("/libStorage/{name}", gcontext.ClearHandler(loggingHandler))
+	r.Handle("/libStorage/servers/{name}",
+		gcontext.ClearHandler(loggingHandler))
 
 	hs := &http.Server{
 		Addr:           laddr,


### PR DESCRIPTION
This patch changes the URL pattern to access libStorage servers. All configured servers are now hosted at `/libStorage/servers/{name}`.