### PR TITLE
Added /libStorage/config

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -168,11 +168,12 @@ func Dial(
 	}
 	log.WithField("host", host).Debug("got libStorage host")
 
-	serverName := config.GetString("libstorage.server")
-	if serverName == "" {
-		return nil, goof.New("libstorage.server is required")
+	serviceName := config.GetString("libstorage.service.name")
+	if serviceName == "" {
+		return nil, goof.New("libstorage.service.name is required")
 	}
-	log.WithField("server", serverName).Debug("got libStorage server name")
+	log.WithField(
+		"serviceName", serviceName).Debug("got libStorage serviceName name")
 
 	if ctx == nil {
 		log.Debug("created empty context for dialer")
@@ -188,7 +189,7 @@ func Dial(
 		return nil, goof.WithField("netProto", netProto, "tcp protocol only")
 	}
 
-	c.url = fmt.Sprintf("http://%s/libStorage/servers/%s", laddr, serverName)
+	c.url = fmt.Sprintf("http://%s/libStorage/services/%s", laddr, serviceName)
 	log.WithField("url", c.url).Debug("got libStorage service URL")
 
 	if err := c.initClientTool(ctx); err != nil {

--- a/libstorage.go
+++ b/libstorage.go
@@ -74,15 +74,11 @@ func Dial(ctx context.Context, config gofig.Config) (client.Client, error) {
 func registerGofigDefaults() {
 	r := gofig.NewRegistration("libStorage")
 	r.Key(gofig.String, "", "", "", "libstorage.host")
-	r.Key(gofig.String, "", "", "", "libstorage.server")
-	r.Key(gofig.String, "", "", "", "libstorage.drivers")
-
+	r.Key(gofig.String, "", "", "", "libstorage.service")
+	r.Key(gofig.String, "", "", "", "libstorage.driver")
 	r.Key(gofig.Bool, "", false, "", "libstorage.profiles.enabled")
 	r.Key(gofig.Bool, "", false, "", "libstorage.profiles.client")
 	r.Key(gofig.String, "", "local=127.0.0.1", "", "libstorage.profiles.groups")
-
-	r.Key(gofig.Int, "", 60, "", "libstorage.service.readtimeout")
-	r.Key(gofig.Int, "", 60, "", "libstorage.service.writetimeout")
 
 	r.Key(gofig.String, "",
 		"/proc/partitions", "", "libstorage.client.localdevicesfile")
@@ -96,14 +92,16 @@ func registerGofigDefaults() {
 	r.Key(gofig.Bool, "",
 		false, "", "libstorage.client.http.logging.logresponse")
 
-	r.Key(gofig.Bool, "", false, "", "libstorage.service.http.logging.enabled")
-	r.Key(gofig.String, "", "", "", "libstorage.service.http.logging.out")
-	r.Key(gofig.String, "", "", "", "libstorage.service.http.logging.err")
+	r.Key(gofig.Int, "", 60, "", "libstorage.server.readtimeout")
+	r.Key(gofig.Int, "", 60, "", "libstorage.server.writetimeout")
+	r.Key(gofig.Bool, "", false, "", "libstorage.server.http.logging.enabled")
+	r.Key(gofig.String, "", "", "", "libstorage.server.http.logging.out")
+	r.Key(gofig.String, "", "", "", "libstorage.server.http.logging.err")
 
 	r.Key(gofig.Bool, "",
-		false, "", "libstorage.service.http.logging.logrequest")
+		false, "", "libstorage.server.http.logging.logrequest")
 	r.Key(gofig.Bool, "",
-		false, "", "libstorage.service.http.logging.logresponse")
+		false, "", "libstorage.server.http.logging.logresponse")
 
 	gofig.Register(r)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -61,15 +61,15 @@ func Serve(config gofig.Config) error {
 
 	si := map[string]*server.ServiceInfo{}
 
-	servers := config.Get("libstorage.service.servers")
-	serversMap := servers.(map[string]interface{})
-	log.WithField("count", len(serversMap)).Debug("got servers map")
+	services := config.Get("libstorage.server.services")
+	servicesMap := services.(map[string]interface{})
+	log.WithField("count", len(servicesMap)).Debug("got services map")
 
-	for name := range serversMap {
-		log.WithField("name", name).Debug("processing server config")
+	for name := range servicesMap {
+		log.WithField("name", name).Debug("processing service config")
 
-		scope := fmt.Sprintf("libstorage.service.servers.%s", name)
-		log.WithField("scope", scope).Debug("getting scoped config for server")
+		scope := fmt.Sprintf("libstorage.server.services.%s", name)
+		log.WithField("scope", scope).Debug("getting scoped config for service")
 		sc := config.Scope(scope)
 
 		service, err := newService(name, sc)


### PR DESCRIPTION
This patch adds the path /libstorage/config for querying the active server configuration. Additionally, the configuration properties have been altered somewhat. What was once "libstorage.service" is now "libstorage.server".