### PR TITLE
Fixes issue of Gnixutils not downloading/updating

### DIFF
--- a/.gomk/include/cross.mk
+++ b/.gomk/include/cross.mk
@@ -42,9 +42,9 @@ build-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_DEPS) $$(GO_SRC_TOOL_MARKERS)
 	$$(ENV) $$(RECURSIVE_INDENT) GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) build
 GO_CROSS_BUILD += build-$$(X_GOOS_$1)_$$(X_GOARCH_$1)
 
-package-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_DEPS) $$(GO_SRC_TOOL_MARKERS)
-	$$(ENV) $$(RECURSIVE_INDENT) GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) package
-GO_CROSS_PACKAGE += package-$$(X_GOOS_$1)_$$(X_GOARCH_$1)
+dist-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_DEPS) $$(GO_SRC_TOOL_MARKERS)
+	$$(ENV) $$(RECURSIVE_INDENT) GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) dist
+GO_CROSS_DIST += dist-$$(X_GOOS_$1)_$$(X_GOARCH_$1)
 
 clean-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_CLEAN_ONCE)
 	$$(ENV) $$(RECURSIVE_INDENT) GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) clean
@@ -70,12 +70,12 @@ endef
 
 $(foreach bp,$(BUILD_PLATFORMS),$(eval $(call CROSS_RULES,$(bp))))
 GO_PHONY += $(GO_CROSS_INSTALL) $(GO_CROSS_BUILD) \
-			$(GO_CROSS_PACKAGE) $(GO_CROSS_CLEAN)
+			$(GO_CROSS_DIST) $(GO_CROSS_CLEAN)
 
 install-all: $(GO_CROSS_INSTALL)
 build-all: $(GO_CROSS_BUILD)
-package-all: $(GO_CROSS_PACKAGE)
+dist-all: $(GO_CROSS_DIST)
 clean-all: $(GO_CROSS_CLEAN)
-GO_PHONY += install-all build-all package-all clean-all
+GO_PHONY += install-all build-all dist-all clean-all
 
 endif

--- a/.gomk/include/deps.mk
+++ b/.gomk/include/deps.mk
@@ -28,13 +28,13 @@ GLIDE_YAML := glide.yaml
 $(GLIDE_LOCK): $(GLIDE_YAML)
 	$(GLIDE_BIN) up
 
-$(GLIDE_LOCK)-clean:
+$(GLIDE_LOCK)-clean: | $(RM)
 	$(RM) -f $(GLIDE_LOCK)
 GO_CLOBBER += $(GLIDE_LOCK)-clean
 
 $(GLIDE_YAML): $(GLIDE_BIN)
 
-$(GLIDE_BIN): | $(GNIX_UTILS)
+$(GLIDE_BIN): | $(MKDIR) $(CURL) $(TAR) $(MKDIR) $(MV)
 	$(MKDIR) -p .glide && \
 		cd .glide && \
 		$(CURL) -S -L -o $(GLIDE_URL_FILE) $(GLIDE_URL) && \
@@ -60,11 +60,11 @@ GO_GET := $(GO_MARKERS_DIR)/go.get
 ifneq (,$(GLIDE_LOCK))
 $(GO_GET): $(GLIDE_LOCK)
 endif
-$(GO_GET): | $(GNIX_UTILS)
+$(GO_GET): | $(TOUCH)
 	go get -v -d -t $(GO_PKG_DIRS)
 	@$(call GO_TOUCH_MARKER,$@)
 
-$(GO_GET)-clean:
+$(GO_GET)-clean: | $(RM)
 	$(RM) -f $(GO_GET)
 GO_CLOBBER += $(GO_GET)-clean
 

--- a/.gomk/include/gnixutils.mk
+++ b/.gomk/include/gnixutils.mk
@@ -4,77 +4,31 @@ ifneq (1,$(IS_GOMK_GNIXUTILS_LOADED))
 IS_GOMK_GNIXUTILS_LOADED := 1
 
 GNIX_SUFFIX := gnix
+GNIX_CLI_SRC_DIR := $(GOPATH)/src/github.com/akutz/gnixutils/cli
 
-RM := $(GO_BIN)/rm-$(GNIX_SUFFIX)
-MKDIR := $(GO_BIN)/mkdir-$(GNIX_SUFFIX)
-TOUCH := $(GO_BIN)/touch-$(GNIX_SUFFIX)
-ENV := $(GO_BIN)/env-$(GNIX_SUFFIX)
-MV := $(GO_BIN)/mv-$(GNIX_SUFFIX)
-CP := $(GO_BIN)/cp-$(GNIX_SUFFIX)
-TAR := $(GO_BIN)/tar-$(GNIX_SUFFIX)
-CURL := $(GO_BIN)/curl-$(GNIX_SUFFIX)
-CAT := $(GO_BIN)/cat-$(GNIX_SUFFIX)
-GREP := $(GO_BIN)/grep-$(GNIX_SUFFIX)
-SED := $(GO_BIN)/sed-$(GNIX_SUFFIX)
-DATE := $(GO_BIN)/date-$(GNIX_SUFFIX)
-PRINTF := $(GO_BIN)/printf-$(GNIX_SUFFIX)
-ECHO := $(PRINTF)
+GNIX_TOOLS := printf rm mkdir touch env mv cp tar curl cat grep sed date
 
-GNIX_UTILS := $(GO_SRC)/github.com/akutz/gnixutils/LICENSE
+define GNIX_TOOLS_DEF
+GNIX_TOOL_BIN_$1 := $$(GO_BIN)/$1-$$(GNIX_SUFFIX)
+GNIX_TOOL_SRC_$1 := $$(GNIX_CLI_SRC_DIR)/$1/$1.go
+$$(call UCASE,$1) := $$(GNIX_TOOL_BIN_$1)
 
-$(GNIX_UTILS):
+ifeq ($1,printf)
+$$(GNIX_TOOL_SRC_$1):
 	go get -v -d -u github.com/akutz/gnixutils
+else
+$$(GNIX_TOOL_SRC_$1): $$(GNIX_CLI_SRC_DIR)/printf/printf.go
+endif
 
-$(RM): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/rm
-GO_DEPS += $(RM)
+gnix-$1: $$(GNIX_TOOL_BIN_$1)
+$$(GNIX_TOOL_BIN_$1): $$(GNIX_TOOL_SRC_$1)
+	go build -o $$@ github.com/akutz/gnixutils/cli/$1
+GO_DEPS += $$(GNIX_TOOL_BIN_$1)
+GNIX_UTILS += $$(GNIX_TOOL_BIN_$1)
 
-$(MKDIR): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/mkdir
-GO_DEPS += $(MKDIR)
+endef
+$(foreach t,$(GNIX_TOOLS),$(eval $(call GNIX_TOOLS_DEF,$(t))))
 
-$(TOUCH): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/touch
-GO_DEPS += $(TOUCH)
-
-$(ENV): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/env
-GO_DEPS += $(ENV)
-
-$(MV): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/mv
-GO_DEPS += $(MV)
-
-$(CP): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/cp
-GO_DEPS += $(CP)
-
-$(TAR): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/tar
-GO_DEPS += $(TAR)
-
-$(CURL): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/curl
-GO_DEPS += $(CURL)
-
-$(CAT): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/cat
-GO_DEPS += $(CAT)
-
-$(GREP): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/grep
-GO_DEPS += $(GREP)
-
-$(SED): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/sed
-GO_DEPS += $(SED)
-
-$(DATE): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/date
-GO_DEPS += $(DATE)
-
-$(PRINTF): | $(GNIX_UTILS)
-	go build -o $@ github.com/akutz/gnixutils/cli/printf
-GO_DEPS += $(PRINTF)
+ECHO := $(PRINTF)
 
 endif

--- a/.gomk/include/tools/source/gocyclo.mk
+++ b/.gomk/include/tools/source/gocyclo.mk
@@ -6,7 +6,7 @@ IS_GOMK_GO_CYCLO_LOADED := 1
 ifeq (1,$(GO_CYCLO_ENABLED))
 
 GOCYCLO_BIN := $(GO_BIN)/gocyclo
-$(GOCYCLO_BIN):
+$(GOCYCLO_BIN): | $(PRINTF)
 	@$(INDENT)
 	go get -v -u github.com/fzipp/gocyclo
 
@@ -15,12 +15,12 @@ GO_CYCLO_MARKER_FILE_$1 := $$(call GO_TOOL_MARKER,$1,cyclo)
 GO_CYCLO_MARKER_PATHS_$2 += $$(GO_CYCLO_MARKER_FILE_$1)
 
 $1-cyclo: $$(GO_CYCLO_MARKER_FILE_$1)
-$$(GO_CYCLO_MARKER_FILE_$1): $1 | $$(GOCYCLO_BIN)
+$$(GO_CYCLO_MARKER_FILE_$1): $1 | $$(GOCYCLO_BIN) $$(TOUCH) $$(PRINTF)
 	@$$(INDENT)
 	gocyclo -over 15 $$?
 	@$$(call GO_TOUCH_MARKER,$$@)
 
-$$(GO_CYCLO_MARKER_FILE_$1)-clean:
+$$(GO_CYCLO_MARKER_FILE_$1)-clean: | $$(RM) $$(PRINTF)
 	@$$(INDENT)
 	$$(RM) -f $$(subst -clean,,$$@)
 GO_PHONY += $$(GO_CYCLO_MARKER_FILE_$1)-clean

--- a/.gomk/include/tools/source/gofmt.mk
+++ b/.gomk/include/tools/source/gofmt.mk
@@ -10,12 +10,12 @@ GO_FMT_MARKER_FILE_$1 := $$(call GO_TOOL_MARKER,$1,fmt)
 GO_FMT_MARKER_PATHS_$2 += $$(GO_FMT_MARKER_FILE_$1)
 
 $1-fmt: $$(GO_FMT_MARKER_FILE_$1)
-$$(GO_FMT_MARKER_FILE_$1): $1
+$$(GO_FMT_MARKER_FILE_$1): $1 | $$(PRINTF) $$(TOUCH)
 	@$$(INDENT)
 	gofmt -w $$?
 	@$$(call GO_TOUCH_MARKER,$$@)
 
-$$(GO_FMT_MARKER_FILE_$1)-clean:
+$$(GO_FMT_MARKER_FILE_$1)-clean: | $$(PRINTF) $$(RM)
 	@$$(INDENT)
 	$$(RM) -f $$(subst -clean,,$$@)
 GO_PHONY += $$(GO_FMT_MARKER_FILE_$1)-clean

--- a/.gomk/include/tools/source/golint.mk
+++ b/.gomk/include/tools/source/golint.mk
@@ -6,14 +6,14 @@ IS_GOMK_GO_LINT_LOADED := 1
 ifeq (1,$(GO_LINT_ENABLED))
 
 GOFGT_BIN := $(GO_BIN)/fgt
-$(GOFGT_BIN):
+$(GOFGT_BIN): | $(PRINTF)
 	@$(INDENT)
 	go get -v -u github.com/GeertJohan/fgt
 
 GO_BUILD_DEPS := $(GOFGT_BIN) $(GO_BUILD_DEPS)
 
 GOLINT_BIN := $(GO_BIN)/golint
-$(GOLINT_BIN): | $(GOFGT_BIN)
+$(GOLINT_BIN): | $(GOFGT_BIN) $(PRINTF)
 	@$(INDENT)
 	go get -v -u github.com/golang/lint/golint
 
@@ -22,12 +22,12 @@ GO_LINT_MARKER_FILE_$1 := $$(call GO_TOOL_MARKER,$1,lint)
 GO_LINT_MARKER_PATHS_$2 += $$(GO_LINT_MARKER_FILE_$1)
 
 $1-lint: $$(GO_LINT_MARKER_FILE_$1)
-$$(GO_LINT_MARKER_FILE_$1): $1 | $$(GOLINT_BIN)
+$$(GO_LINT_MARKER_FILE_$1): $1 | $$(GOLINT_BIN) $(PRINTF) $(TOUCH)
 	@$$(INDENT)
 	fgt golint $$?
 	@$$(call GO_TOUCH_MARKER,$$@)
 
-$$(GO_LINT_MARKER_FILE_$1)-clean:
+$$(GO_LINT_MARKER_FILE_$1)-clean: | $$(PRINTF) $$(RM)
 	@$$(INDENT)
 	$$(RM) -f $$(subst -clean,,$$@)
 GO_PHONY += $$(GO_LINT_MARKER_FILE_$1)-clean

--- a/.gomk/include/tools/source/govet.mk
+++ b/.gomk/include/tools/source/govet.mk
@@ -10,12 +10,12 @@ GO_VET_MARKER_FILE_$1 := $$(call GO_TOOL_MARKER,$1,vet)
 GO_VET_MARKER_PATHS_$2 += $$(GO_VET_MARKER_FILE_$1)
 
 $1-vet: $$(GO_VET_MARKER_FILE_$1)
-$$(GO_VET_MARKER_FILE_$1): $1
+$$(GO_VET_MARKER_FILE_$1): $1 | $(PRINTF) $(ENV) $(TOUCH)
 	@$$(INDENT)
 	$(ENV) GOOS=$(SYS_GOOS) GOARCH=$(SYS_GOARCH) go vet $$?
 	@$$(call GO_TOUCH_MARKER,$$@)
 
-$$(GO_VET_MARKER_FILE_$1)-clean:
+$$(GO_VET_MARKER_FILE_$1)-clean: | $$(PRINTF) $$(RM)
 	@$$(INDENT)
 	$$(RM) -f $$(subst -clean,,$$@)
 GO_PHONY += $$(GO_VET_MARKER_FILE_$1)-clean

--- a/.gomk/include/tools/test/codecov.mk
+++ b/.gomk/include/tools/test/codecov.mk
@@ -25,19 +25,19 @@ GO_DEPS += $(GO_COVER_DEPS)
 CODECOV_PROFILE := $(GO_TESTS_DIR)/codecov.out
 CODECOV_MARKER := $(GO_MARKERS_DIR)/go.codecov
 
-$(CODECOV_PROFILE): $(GO_COVER_PROFILES)
-	echo "mode: set" > $@
+$(CODECOV_PROFILE): $(GO_COVER_PROFILES) | $(PRINTF) $(GREP)
+	$(PRINTF) "mode: set\n" > $@
 	$(foreach f,$?,$(GREP) -v "mode: set" $(f) >> $@ &&) true
 
-$(CODECOV_PROFILE)-clean:
+$(CODECOV_PROFILE)-clean: | $(RM)
 	$(RM) -f $(CODECOV_PROFILE)
 
 GO_COVER := $(CODECOV_MARKER)
-$(CODECOV_MARKER): $(CODECOV_PROFILE)
+$(CODECOV_MARKER): $(CODECOV_PROFILE) | $(CURL) $(TOUCH)
 	curl -sSL https://codecov.io/bash | bash -s -- -f $?
 	@$(call GO_TOUCH_MARKER,$@)
 
-$(CODECOV_MARKER)-clean:
+$(CODECOV_MARKER)-clean: | $(RM)
 	$(RM) -f $(CODECOV_MARKER)
 
 GO_COVER_CLEAN := $(CODECOV_PROFILE)-clean $(CODECOV_MARKER)-clean

--- a/.gomk/include/version.mk
+++ b/.gomk/include/version.mk
@@ -5,7 +5,7 @@ IS_GOMK_VERSION_LOADED := 1
 
 VERSION_DEPS := $(SED) $(GREP) $(CAT)
 
-ifneq (,$(wildcard $(VERSION_DEPS)))
+ifeq ($(words $(VERSION_DEPS)),$(words $(wildcard $(VERSION_DEPS))))
 ifneq (,$(wildcard .git))
 
 include $(GOMK_I)/arch.mk

--- a/Makefile
+++ b/Makefile
@@ -26,17 +26,17 @@ clean: $(GO_CLEAN)
 
 clobber: $(GO_CLOBBER)
 
-run:
+run: | $(ENV)
 	$(ENV) GOMK_TOOLS_ENABLE=1 GO_TAGS='run mock driver' $(MAKE) install
 	$(ENV) GOMK_TOOLS_ENABLE=1 GO_TAGS='run mock driver' $(MAKE) test
 
-run-debug:
+run-debug: | $(ENV)
 	$(ENV) LIBSTORAGE_DEBUG=true $(MAKE) run
 
-run-tls:
+run-tls: | $(ENV)
 	$(ENV) LIBSTORAGE_TESTRUN_TLS=true $(MAKE) run
 
-run-tls-debug:
+run-tls-debug: | $(ENV)
 	$(ENV) LIBSTORAGE_TESTRUN_TLS=true $(MAKE) run-debug
 
 .PHONY: all install build deps \

--- a/api/utils/schema/gomk.properties
+++ b/api/utils/schema/gomk.properties
@@ -1,8 +1,7 @@
 LIBSTORAGE_JSON := ./libstorage.json
 LIBSTORAGE_JSON_EMBEDDED := ./api/utils/schema/schema_generated.go
-LIBSTORAGE_JSON_SCHEMA := $(shell $(CAT) $(LIBSTORAGE_JSON))
 
-$(LIBSTORAGE_JSON_EMBEDDED):: $(LIBSTORAGE_JSON) | $(PRINTF)
+$(LIBSTORAGE_JSON_EMBEDDED):: $(LIBSTORAGE_JSON) | $(PRINTF) $(SED)
 	@$(PRINTF) "package schema\n\nconst (\n" >$@
 	@$(PRINTF) "\t// JSONSchema is the libStorage API JSON schema\n" >>$@
 	@$(PRINTF) "\tJSONSchema = \`" >>$@


### PR DESCRIPTION
This patch address issue #10, fixing an issue where the Gnixutils were not properly listed as dependencies for targets that used them, and thus resulting in a situation where the utilities were not updated as necessary.