### PR TITLE
Fix for tool binary paths

### DIFF
--- a/.gomk/include/tools/source/gocyclo.mk
+++ b/.gomk/include/tools/source/gocyclo.mk
@@ -17,7 +17,7 @@ GO_CYCLO_MARKER_PATHS_$2 += $$(GO_CYCLO_MARKER_FILE_$1)
 $1-cyclo: $$(GO_CYCLO_MARKER_FILE_$1)
 $$(GO_CYCLO_MARKER_FILE_$1): $1 | $$(GOCYCLO_BIN) $$(TOUCH) $$(PRINTF)
 	@$$(INDENT)
-	gocyclo -over 15 $$?
+	$$(GOCYCLO_BIN) -over 15 $$?
 	@$$(call GO_TOUCH_MARKER,$$@)
 
 $$(GO_CYCLO_MARKER_FILE_$1)-clean: | $$(RM) $$(PRINTF)

--- a/.gomk/include/tools/source/golint.mk
+++ b/.gomk/include/tools/source/golint.mk
@@ -24,7 +24,7 @@ GO_LINT_MARKER_PATHS_$2 += $$(GO_LINT_MARKER_FILE_$1)
 $1-lint: $$(GO_LINT_MARKER_FILE_$1)
 $$(GO_LINT_MARKER_FILE_$1): $1 | $$(GOLINT_BIN) $(PRINTF) $(TOUCH)
 	@$$(INDENT)
-	fgt golint $$?
+	$$(GOFGT_BIN) $$(GOLINT_BIN) $$?
 	@$$(call GO_TOUCH_MARKER,$$@)
 
 $$(GO_LINT_MARKER_FILE_$1)-clean: | $$(PRINTF) $$(RM)


### PR DESCRIPTION
This patch fixes an issue where the go tools gocyclo and golint are not being executed using the full paths.