### PR TITLE
Updated description of NetworkName

### DIFF
--- a/api/types/types_model.go
+++ b/api/types/types_model.go
@@ -125,7 +125,8 @@ type Volume struct {
 	// The name of the volume.
 	Name string `json:"name"`
 
-	// The name of the network on which the volume resides.
+	// NetworkName is the name the device is known by in order to discover
+	// locally.
 	NetworkName string `json:"networkName,omitempty"`
 
 	// The size of the volume.


### PR DESCRIPTION
The description now represents the real usage for the parameter. It is used when a storage platform is advertising a device to a networked host.  The networked host needs to a hint or name that it can use to properly discover the device being advertised.