### PR TITLE
The executor CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ vendor/
 .project
 glide.lock
 .gomk/tmp
+api/server/executors/executors_generated.go
 
 # Created by https://www.gitignore.io
 

--- a/.gomk/config.mk
+++ b/.gomk/config.mk
@@ -97,11 +97,9 @@ INDENT_LEN ?=
 
 # the tags for building go code
 ifeq ($(origin GO_TAGS),undefined)
-GO_TAGS ?= mock driver
+GO_TAGS ?= $(DRIVERS)
+GO_TAGS += driver
 endif
-#ifneq (,$(GO_TAGS))
-#GO_TAGS_FILENAME := $(subst $(SPACE),_,$(GOTAGS))
-#endif
 STRIP_GO_TAGS = $(subst $(COMMA)_,$(COMMA)$(SPACE),$(patsubst -tags%,,$(subst -tags$(SPACE),-tags_,$(subst $(COMMA)$(SPACE),$(COMMA)_,$1))))
 
 # flags to use with go build

--- a/.gomk/include/cross.mk
+++ b/.gomk/include/cross.mk
@@ -34,34 +34,30 @@ endif
 
 ifeq (,$2)
 
-install-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_DEPS) $$(GO_SRC_TOOL_MARKERS)
-	$$(ENV) $$(RECURSIVE_INDENT) GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) install
-GO_CROSS_INSTALL += install-$$(X_GOOS_$1)_$$(X_GOARCH_$1)
-
-build-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_DEPS) $$(GO_SRC_TOOL_MARKERS)
-	$$(ENV) $$(RECURSIVE_INDENT) GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) build
+build-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_DEPS) $$(GO_SRC_TOOL_MARKERS) | $$(ENV)
+	$$(ENV) $$(RECURSIVE_INDENT) GOMK_TOOLS_ENABLE=0 GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) build
 GO_CROSS_BUILD += build-$$(X_GOOS_$1)_$$(X_GOARCH_$1)
 
-dist-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_DEPS) $$(GO_SRC_TOOL_MARKERS)
-	$$(ENV) $$(RECURSIVE_INDENT) GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) dist
+#build-executors-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_DEPS) $$(GO_SRC_TOOL_MARKERS) | $$(ENV)
+#	$$(ENV) $$(RECURSIVE_INDENT) GOMK_TOOLS_ENABLE=0 GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) build-executors
+#GO_CROSS_BUILD_EXECUTORS += build-executors-$$(X_GOOS_$1)_$$(X_GOARCH_$1)
+
+dist-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_DEPS) $$(GO_SRC_TOOL_MARKERS) | $$(ENV)
+	$$(ENV) $$(RECURSIVE_INDENT) GOMK_TOOLS_ENABLE=0 GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) dist
 GO_CROSS_DIST += dist-$$(X_GOOS_$1)_$$(X_GOARCH_$1)
 
-clean-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_CLEAN_ONCE)
-	$$(ENV) $$(RECURSIVE_INDENT) GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) clean
+clean-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_CLEAN_ONCE) | $$(ENV)
+	$$(ENV) $$(RECURSIVE_INDENT) GOMK_TOOLS_ENABLE=0 GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) clean
 GO_CROSS_CLEAN += clean-$$(X_GOOS_$1)_$$(X_GOARCH_$1)
 
 else
 
-$3-install-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_DEPS) $$(GO_SRC_TOOL_MARKERS)
-	$$(ENV) $$(RECURSIVE_INDENT) GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) $2 install
-GO_CROSS_INSTALL += $3-install-$$(X_GOOS_$1)_$$(X_GOARCH_$1)
-
-$3-build-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_DEPS) $$(GO_SRC_TOOL_MARKERS)
-	$$(ENV) $$(RECURSIVE_INDENT) GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) $2 build
+$3-build-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_DEPS) $$(GO_SRC_TOOL_MARKERS) | $$(ENV)
+	$$(ENV) $$(RECURSIVE_INDENT) GOMK_TOOLS_ENABLE=0 GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) $2 build
 GO_CROSS_BUILD += $3-build-$$(X_GOOS_$1)_$$(X_GOARCH_$1)
 
-$3-clean-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_CLEAN_ONCE)
-	$$(ENV) $$(RECURSIVE_INDENT) GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) $2 clean
+$3-clean-$$(X_GOOS_$1)_$$(X_GOARCH_$1): $$(GO_CLEAN_ONCE) | $$(ENV)
+	$$(ENV) $$(RECURSIVE_INDENT) GOMK_TOOLS_ENABLE=0 GOOS=$$(X_GOOS_$1) GOARCH=$$(X_GOARCH_$1) $$(MAKE) $2 clean
 GO_CROSS_CLEAN += $3-clean-$$(X_GOOS_$1)_$$(X_GOARCH_$1)
 
 endif
@@ -69,13 +65,16 @@ endif
 endef
 
 $(foreach bp,$(BUILD_PLATFORMS),$(eval $(call CROSS_RULES,$(bp))))
-GO_PHONY += $(GO_CROSS_INSTALL) $(GO_CROSS_BUILD) \
+#GO_PHONY += $(GO_CROSS_BUILD) $(GO_CROSS_BUILD_EXECUTORS) \
+
+GO_PHONY += $(GO_CROSS_BUILD) \
 			$(GO_CROSS_DIST) $(GO_CROSS_CLEAN)
 
-install-all: $(GO_CROSS_INSTALL)
 build-all: $(GO_CROSS_BUILD)
+#build-executors-all: $(GO_CROSS_BUILD_EXECUTORS)
 dist-all: $(GO_CROSS_DIST)
 clean-all: $(GO_CROSS_CLEAN)
-GO_PHONY += install-all build-all dist-all clean-all
+#GO_PHONY += build-all build-executors-all dist-all clean-all
+GO_PHONY += build-all dist-all clean-all
 
 endif

--- a/.gomk/include/deps.mk
+++ b/.gomk/include/deps.mk
@@ -55,7 +55,7 @@ endif
 ##                                 GO GET                                     ##
 ################################################################################
 ifeq (1,$(GO_GET_ENABLED))
-GO_GET := $(GO_MARKERS_DIR)/go.get
+GO_GET := $(GOMK_TMP_DIR)/markers/go.get
 
 ifneq (,$(GLIDE_LOCK))
 $(GO_GET): $(GLIDE_LOCK)

--- a/.gomk/include/tools/pkg/gobindata.mk
+++ b/.gomk/include/tools/pkg/gobindata.mk
@@ -1,0 +1,11 @@
+ifneq (1,$(IS_GOMK_GOBINDATA_LOADED))
+
+# note that the file is loaded
+IS_GOMK_GOBINDATA_LOADED := 1
+
+GOBINDATA := $(GOPATH)/bin/go-bindata
+
+$(GOBINDATA):
+	go get -u github.com/jteeuwen/go-bindata/...
+
+endif

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-all: install
+# the space-delimited list of drivers for which to build the libstorage
+# server, client(s), and executor(s)
+DRIVERS := mock
+
+all: build
 
 include .gomk/go.mk
 
@@ -6,7 +10,9 @@ deps: $(GO_DEPS)
 
 build: $(GO_BUILD)
 
-install: $(GO_INSTALL)
+install: $(GO_BUILD)
+
+build-executors: $(LIBSTORAGE_EXECUTORS)
 
 test-build: $(GO_TEST_BUILD)
 
@@ -27,8 +33,8 @@ clean: $(GO_CLEAN)
 clobber: $(GO_CLOBBER)
 
 run: | $(ENV)
-	$(ENV) GOMK_TOOLS_ENABLE=1 GO_TAGS='run mock driver' $(MAKE) install
-	$(ENV) GOMK_TOOLS_ENABLE=1 GO_TAGS='run mock driver' $(MAKE) test
+	$(ENV) GOMK_TOOLS_ENABLE=1 GO_TAGS='$(DRIVERS) driver' $(MAKE)
+	$(ENV) GOMK_TOOLS_ENABLE=1 GO_TAGS='run $(DRIVERS) driver' $(MAKE) test
 
 run-debug: | $(ENV)
 	$(ENV) LIBSTORAGE_DEBUG=true $(MAKE) run
@@ -39,9 +45,7 @@ run-tls: | $(ENV)
 run-tls-debug: | $(ENV)
 	$(ENV) LIBSTORAGE_TESTRUN_TLS=true $(MAKE) run-debug
 
-.PHONY: all install build deps \
-		test test-build test-clean \
-		test-mock test-build-mock \
+.PHONY: all \
 		cover cover-clean \
 		dist dist-clean \
 		clean clobber \

--- a/api/server/executors/executors.go
+++ b/api/server/executors/executors.go
@@ -1,0 +1,1 @@
+package executors

--- a/api/server/executors/gomk.properties
+++ b/api/server/executors/gomk.properties
@@ -1,0 +1,75 @@
+
+define LIBSTORAGE_EXECUTORS_XBUILD_DEF
+
+LSEXB_X_BP_$1_$2 := $$(subst -, ,$2)
+LSEXB_X_BP_OS_$1_$2 := $$(firstword $$(LSEXB_X_BP_$1_$2))
+LSEXB_X_BP_ARCH_$1_$2 := $$(lastword $$(LSEXB_X_BP_$1_$2))
+
+ifeq (Linux,$$(LSEXB_X_BP_OS_$1_$2))
+	LSEXB_X_GOOS_$1_$2 := linux
+else
+	ifeq (Darwin,$$(LSEXB_X_BP_OS_$1_$2))
+		LSEXB_X_GOOS_$1_$2 := darwin
+	else
+		ifeq (Windows,$$(LSEXB_X_BP_OS_$1_$2))
+			LSEXB_X_GOOS_$1_$2 := windows
+		endif
+	endif
+endif
+
+ifeq (i386,$$(LSEXB_X_BP_ARCH_$1_$2))
+	LSEXB_X_GOARCH_$1_$2 := 386
+else
+	ifeq (x86_64,$$(LSEXB_X_BP_ARCH_$1_$2))
+		LSEXB_X_GOARCH_$1_$2 := amd64
+	endif
+endif
+
+ifeq (1,$(RECURSIVE))
+	RECURSIVE_INDENT := INDENT_LEN=$$(INDENT_LEN)
+endif
+
+$1-executor-$$(LSEXB_X_GOOS_$1_$2)_$$(LSEXB_X_GOARCH_$1_$2) := $$(GOMK_TMP_DIR)/$1_executor/build/bin/$$(LSEXB_X_GOOS_$1_$2)_$$(LSEXB_X_GOARCH_$1_$2)/libstorage-$1-executor
+$1-executor-build-$$(LSEXB_X_GOOS_$1_$2)_$$(LSEXB_X_GOARCH_$1_$2): $$($1-executor-$$(LSEXB_X_GOOS_$1_$2)_$$(LSEXB_X_GOARCH_$1_$2))
+$$($1-executor-$$(LSEXB_X_GOOS_$1_$2)_$$(LSEXB_X_GOARCH_$1_$2)): | $$(ENV)
+	$$(ENV) $$(RECURSIVE_INDENT) \
+		GOMK_TOOLS_ENABLE=1 \
+		GO_TAGS='$1 executor' \
+		LIBSTORAGE_EXECUTOR_DRIVER=$1 \
+		BUILD_EXECUTOR=1 \
+		GOOS=$$(LSEXB_X_GOOS_$1_$2) \
+		GOARCH=$$(LSEXB_X_GOARCH_$1_$2) \
+		$$(MAKE) build-executor
+
+$$($1-executor-$$(LSEXB_X_GOOS_$1_$2)_$$(LSEXB_X_GOARCH_$1_$2))-clean: | $$(RM)
+	$(RM) -f $$($1-executor-$$(LSEXB_X_GOOS_$1_$2)_$$(LSEXB_X_GOARCH_$1_$2))
+GO_PHONY += $$($1-executor-$$(LSEXB_X_GOOS_$1_$2)_$$(LSEXB_X_GOARCH_$1_$2))-clean
+GO_CLEAN += $$($1-executor-$$(LSEXB_X_GOOS_$1_$2)_$$(LSEXB_X_GOARCH_$1_$2))-clean
+
+LIBSTORAGE_EXECUTORS += $$($1-executor-$$(LSEXB_X_GOOS_$1_$2)_$$(LSEXB_X_GOARCH_$1_$2))
+
+endef
+
+define LIBSTORAGE_EXECUTORS_DEF
+$$(foreach bp,$$(BUILD_PLATFORMS),$$(eval $$(call LIBSTORAGE_EXECUTORS_XBUILD_DEF,$1,$$(bp))))
+endef
+
+ifneq (1,$(BUILD_EXECUTOR))
+$(foreach d,$(DRIVERS),$(eval $(call LIBSTORAGE_EXECUTORS_DEF,$(d))))
+endif
+
+LIBSTORAGE_EXECUTORS_EMBEDDED := ./api/server/executors/executors_generated.go
+build-embedded-executors: $(LIBSTORAGE_EXECUTORS_EMBEDDED)
+$(LIBSTORAGE_EXECUTORS_EMBEDDED): $(LIBSTORAGE_EXECUTORS) | $(GOBINDATA)
+	$(GOBINDATA) -tags '$(DRIVERS)' \
+                 -pkg executors \
+                 -o $@ \
+                 -prefix "$(GO_TMP_BUILD_DIR)/bin/" \
+                 $(dir $(LIBSTORAGE_EXECUTORS))
+$(LIBSTORAGE_EXECUTORS_EMBEDDED)-clean: | $(RM)
+	$(RM) -f $(LIBSTORAGE_EXECUTORS_EMBEDDED)
+
+GO_CLEAN += $(LIBSTORAGE_EXECUTORS_EMBEDDED)-clean
+GO_PHONY += $(LIBSTORAGE_EXECUTORS_EMBEDDED)-clean
+
+GO_PKG_BUILD_DEPS_./api/server/executors += $(LIBSTORAGE_EXECUTORS_EMBEDDED)

--- a/api/server/gomk.properties
+++ b/api/server/gomk.properties
@@ -1,0 +1,2 @@
+GO_PKG_BUILD_DEPS_./api/server += ./api/server/executors/executors_generated.go
+GO_PKG_BUILD_DEPS_./api/server += $(GO_TMP_BUILD_PKG_DIR)/libstorage/api/server/executors.a

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,1 @@
+package cli

--- a/cli/executor/executor.go
+++ b/cli/executor/executor.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/emccode/libstorage/api/registry"
+	"github.com/emccode/libstorage/api/types/context"
+	"github.com/emccode/libstorage/api/utils"
+
+	// load the storage drivers
+	_ "github.com/emccode/libstorage/drivers/storage"
+)
+
+var (
+	cmdRx = regexp.MustCompile("(?i)instanceid|nextdevice|localdevices")
+)
+
+func main() {
+
+	args := os.Args
+	if len(args) != 2 {
+		printUsageAndExit()
+	}
+
+	cmd := cmdRx.FindString(args[1])
+	if cmd == "" {
+		printUsageAndExit()
+	}
+	cmd = strings.ToLower(cmd)
+
+	d := <-registry.StorageDrivers()
+	if d == nil {
+		fmt.Fprintln(os.Stderr, "error: no storage driver available")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	store := utils.NewStore()
+
+	var (
+		err    error
+		result interface{}
+		op     string
+	)
+
+	if cmd == "instanceid" {
+		op = "instance ID"
+		opResult, opErr := d.InstanceID(ctx, store)
+		if opErr != nil {
+			err = opErr
+		} else {
+			result = opResult
+		}
+	} else if cmd == "nextdevice" {
+		op = "next device"
+		opResult, opErr := d.NextDevice(ctx, store)
+		if opErr != nil {
+			err = opErr
+		} else {
+			result = opResult
+		}
+	} else if cmd == "localdevices" {
+		op = "local devices"
+		opResult, opErr := d.LocalDevices(ctx, store)
+		if opErr != nil {
+			err = opErr
+		} else {
+			result = opResult
+		}
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"error: error getting %s: %v\n", op, err)
+		os.Exit(1)
+	}
+
+	switch result.(type) {
+	case string:
+		fmt.Fprintln(os.Stdout, result)
+	default:
+		buf, err := json.Marshal(result)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: error encoding %s: %v\n", op, err)
+			os.Exit(1)
+		}
+		str := string(buf)
+		if str == "null" {
+			fmt.Fprintf(os.Stdout, "{}\n")
+		} else {
+			fmt.Fprintf(os.Stdout, "%s\n", str)
+		}
+	}
+}
+
+func printUsage() {
+	fmt.Printf(
+		"usage: %s instanceID|nextDevice|localDevices\n",
+		path.Base(os.Args[0]))
+}
+
+func printUsageAndExit() {
+	printUsage()
+	os.Exit(1)
+}

--- a/cli/executor/gomk.properties
+++ b/cli/executor/gomk.properties
@@ -1,0 +1,8 @@
+ifeq (,$(LIBSTORAGE_EXECUTOR_DRIVER))
+LIBSTORAGE_EXECUTOR_DRIVER := mock
+endif
+
+ifeq (1,$(BUILD_EXECUTOR))
+GO_BUILD_OUTPUT_FILE_./cli/executor := $(GO_TMP_BUILD_BIN_DIR)/libstorage-$(LIBSTORAGE_EXECUTOR_DRIVER)-executor
+build-executor: $(GO_BUILD_OUTPUT_FILE_./cli/executor)
+endif

--- a/drivers/storage/mock/mock_nodriver.go
+++ b/drivers/storage/mock/mock_nodriver.go
@@ -9,6 +9,10 @@ import (
 	"github.com/emccode/libstorage/api/types/drivers"
 )
 
+func (d *driver) NextDeviceInfo() *types.NextDeviceInfo {
+	return nil
+}
+
 func (d *driver) InstanceInspect(
 	ctx context.Context,
 	opts types.Store) (*types.Instance, error) {


### PR DESCRIPTION
This patch introduces the executor CLI that is built for each driver. To build executors use the following Make targets:

 Target | Description 
----------|----------------
`build-executor` | builds the executor with the default driver (`mock`) for the system `$GOOS_$GOARCH`
`build-executors` | builds the executors for all drivers for the system `$GOOS_$GOARCH`
`build-executors-all` | builds the executors for all drivers for all `$GOOS_$GOARCH` combinations
`build-executor-$GOOS_$GOARCH` | builds the executor with the default driver (`mock`) for the system `$GOOS_$GOARCH`

It's also possible to build an executor for a non-default driver and/or non-system `$GOOS_$GOARCH` combination without resorting to the multi-build targets. Invoke the `build-executor` or `build-executor-$GOOS_$GOARCH` targets specifying different go tags. For example:

```
env GO_TAGS='ec2 driver' make build-executor
```

The above command will build the executor for the `ec2` driver for the system `$GOOS_$GOARCH`. To build the `ec2` driver for a 64-bit Linux system, the command would be:

```
env GOOS=linux GOARCH=amd64 GO_TAGS='ec2 driver' make build-executor
```