### PR TITLE
Added Filtering to Volume and Snapshot GET REST calls

### DIFF
--- a/api/server/router/snapshot/snapshot_routes.go
+++ b/api/server/router/snapshot/snapshot_routes.go
@@ -18,7 +18,7 @@ import (
 
 //the filtering mechanism applies a simple match, you could do something like
 //this future https://github.com/golang/appengine/blob/master/datastore/query.go
-func applyFilter(obj *types.Volume, filters map[string][]string) bool {
+func applyFilter(obj *types.Snapshot, filters map[string][]string) bool {
 	include := true
 	for key, values := range filters {
 		//fmt.Print("Filter Key: ", key, "\n")

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -27,6 +27,49 @@ type volumesRoute struct {
 	queryAttachments bool
 }
 
+//the filtering mechanism applies a simple match, you could do something like
+//this future https://github.com/golang/appengine/blob/master/datastore/query.go
+func applyFilter(obj *types.Volume, filters map[string][]string) bool {
+	include := true
+	for key, values := range filters {
+		//fmt.Print("Filter Key: ", key, "\n")
+		if len(obj.Fields[key]) == 0 {
+			//fmt.Print("Key ", key, " not found\n")
+			include = false
+			break
+		}
+		if !include {
+			//fmt.Print("Exiting early with no key found\n")
+			break
+		}
+
+		found := false
+		for _, value := range values {
+			//fmt.Print("Filter Val: ", value, "\n")
+			//omit adding to the slice if the key and value doesnt exist
+			if strings.Compare(value, obj.Fields[key]) == 0 {
+				//fmt.Print(value, " = ", obj.Fields[key], "\n")
+				found = true //key exists and value exists in the map
+				break
+			}
+		}
+		if !found {
+			//fmt.Print("Exiting early with no value found\n")
+			include = false
+			break
+		}
+
+		//fmt.Print("Found: ", found, "\n")
+		include = include && found
+		if !include {
+			//fmt.Print("Exiting early with no key found\n")
+			break
+		}
+	}
+
+	return include
+}
+
 func (r *volumesRoute) volumes(ctx context.Context,
 	w http.ResponseWriter,
 	req *http.Request,
@@ -64,20 +107,8 @@ func (r *volumesRoute) volumes(ctx context.Context,
 
 			objMap := map[string]*types.Volume{}
 			for _, obj := range objs {
-				//omit adding to the slice if the key and value doesnt exist
-				omit := true
-				for key, value := range obj.Fields {
-					if len(filters[key]) == 0 {
-						break //key doesnt exist
-					}
-					for testval := range filters[key] {
-						if strings.Compare(value, testval) == 0 {
-							omit = false //key exists and value exists in the map
-						}
-					}
-				}
-				if omit {
-					continue
+				if !applyFilter(obj, filters) {
+					continue //object didnt not meet filter requirements
 				}
 				objMap[obj.ID] = obj
 			}
@@ -149,20 +180,8 @@ func (r *volumesRoute) volumesForService(
 		}
 
 		for _, obj := range objs {
-			//omit adding to the slice if the key and value doesnt exist
-			omit := true
-			for key, value := range obj.Fields {
-				if len(filters[key]) == 0 {
-					break //key doesnt exist
-				}
-				for testval := range filters[key] {
-					if strings.Compare(value, testval) == 0 {
-						omit = false //key exists and value exists in the map
-					}
-				}
-			}
-			if omit {
-				continue
+			if !applyFilter(obj, filters) {
+				continue //object didnt not meet filter requirements
 			}
 			reply[obj.ID] = obj
 		}


### PR DESCRIPTION
Added Filtering to Volume and Snapshot GET REST calls

Based on research on how others like Google, VMware, and etc pass filters into REST API calls for GETting objects, filter parameters can be added by appending query parameters on the URI to the REST call.

As an example for libstorage and retrieving volumes, making a call with the following URI will give you all volumes in datacenter durham.
```
GET http://<REST endpoint>/volumes?datacenter=durham
```

You can filter on multiple Fields and the behavior is such that all fields must be satisfied in order to be returned in the result set of the REST API call. For example if you have the following volume objects:
```
Volume1 {
   Fields: {"datacenter": "durham", "department": "finance"}
}
Volume2 {
   Fields: {"datacenter": "irvine", "department": "finance"}
}
```

And you make the following REST API call:
```
GET http://<REST endpoint>/volumes?datacenter=irvine&department=finance
```

Only Volume2 will be returned in the result set.

It should be noted that currently Fields aren't not being populated (I believe Chris is working on this) but I did test this by simulating the logic here with fake data:
https://github.com/dvonthenen/goprojects/blob/master/src/sandbox/main.go 