### PR TITLE
WiP - Introducing a Filters Library

### DIFF
--- a/api/server/router/snapshot/snapshot_routes.go
+++ b/api/server/router/snapshot/snapshot_routes.go
@@ -9,9 +9,11 @@ import (
 	"github.com/emccode/libstorage/api/server/services"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/types/context"
+	"github.com/emccode/libstorage/api/types/drivers"
 	apihttp "github.com/emccode/libstorage/api/types/http"
 	apisvcs "github.com/emccode/libstorage/api/types/services"
 	"github.com/emccode/libstorage/api/utils"
+	"github.com/emccode/libstorage/api/utils/filters"
 	"github.com/emccode/libstorage/api/utils/schema"
 )
 
@@ -27,13 +29,21 @@ func (r *router) snapshots(
 		reply   apihttp.ServiceSnapshotMap = map[string]apihttp.SnapshotMap{}
 	)
 
+	opts := &drivers.SnapshotsOpts{Opts: store}
+	if store.IsSet("filter") {
+		filter, err := filters.CompileFilter(store.GetString("filter"))
+		if err == nil {
+			opts.Filter = filter
+		}
+	}
+
 	for service := range services.StorageServices() {
 
 		run := func(
 			ctx context.Context,
 			svc apisvcs.StorageService) (interface{}, error) {
 
-			objs, err := svc.Driver().Snapshots(ctx, store)
+			objs, err := svc.Driver().Snapshots(ctx, opts)
 			if err != nil {
 				return nil, err
 			}
@@ -89,13 +99,22 @@ func (r *router) snapshotsForService(
 		return err
 	}
 
+	opts := &drivers.SnapshotsOpts{Opts: store}
+	if store.IsSet("filter") {
+		filter, err := filters.CompileFilter(store.GetString("filter"))
+		if err == nil {
+			opts.Filter = filter
+		}
+	}
+
 	run := func(
 		ctx context.Context,
 		svc apisvcs.StorageService) (interface{}, error) {
 
 		var reply apihttp.SnapshotMap = map[string]*types.Snapshot{}
 
-		objs, err := svc.Driver().Snapshots(ctx, store)
+		objs, err := svc.Driver().Snapshots(ctx, opts)
+
 		if err != nil {
 			return nil, err
 		}

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -14,6 +14,7 @@ import (
 	apihttp "github.com/emccode/libstorage/api/types/http"
 	apisvcs "github.com/emccode/libstorage/api/types/services"
 	"github.com/emccode/libstorage/api/utils"
+	"github.com/emccode/libstorage/api/utils/filters"
 	"github.com/emccode/libstorage/api/utils/schema"
 )
 
@@ -36,6 +37,14 @@ func (r *volumesRoute) volumes(ctx context.Context,
 		attachments = store.GetBool("attachments")
 	}
 
+	opts := &drivers.VolumesOpts{Attachments: attachments, Opts: store}
+	if store.IsSet("filter") {
+		filter, err := filters.CompileFilter(store.GetString("filter"))
+		if err == nil {
+			opts.Filter = filter
+		}
+	}
+
 	var (
 		tasks   = map[string]*types.Task{}
 		taskIDs []int
@@ -48,11 +57,7 @@ func (r *volumesRoute) volumes(ctx context.Context,
 			ctx context.Context,
 			svc apisvcs.StorageService) (interface{}, error) {
 
-			objs, err := svc.Driver().Volumes(
-				ctx, &drivers.VolumesOpts{
-					Attachments: attachments,
-					Opts:        store,
-				})
+			objs, err := svc.Driver().Volumes(ctx, opts)
 			if err != nil {
 				return nil, err
 			}
@@ -108,18 +113,26 @@ func (r *volumesRoute) volumesForService(
 		return err
 	}
 
+	var attachments bool
+	if r.queryAttachments {
+		attachments = store.GetBool("attachments")
+	}
+
+	opts := &drivers.VolumesOpts{Attachments: attachments, Opts: store}
+	if store.IsSet("filter") {
+		filter, err := filters.CompileFilter(store.GetString("filter"))
+		if err == nil {
+			opts.Filter = filter
+		}
+	}
+
 	run := func(
 		ctx context.Context,
 		svc apisvcs.StorageService) (interface{}, error) {
 
 		var reply apihttp.VolumeMap = map[string]*types.Volume{}
 
-		objs, err := svc.Driver().Volumes(
-			ctx,
-			&drivers.VolumesOpts{
-				Attachments: store.GetBool("attachments"),
-				Opts:        store,
-			})
+		objs, err := svc.Driver().Volumes(ctx, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/api/types/drivers/drivers_storage.go
+++ b/api/types/drivers/drivers_storage.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/types/context"
+	"github.com/emccode/libstorage/api/types/filters"
 )
 
 // NewStorageExecutor is a function that constructs a new StorageExecutors.
@@ -11,9 +12,10 @@ type NewStorageExecutor func() StorageExecutor
 // NewStorageDriver is a function that constructs a new StorageDriver.
 type NewStorageDriver func() StorageDriver
 
-// VolumesOpts are options when inspecting a volume.
+// VolumesOpts are options when querying volumes.
 type VolumesOpts struct {
 	Attachments bool
+	Filter      *filters.Filter
 	Opts        types.Store
 }
 
@@ -36,6 +38,12 @@ type VolumeCreateOpts struct {
 type VolumeAttachByIDOpts struct {
 	NextDevice *string
 	Opts       types.Store
+}
+
+// SnapshotsOpts are options when querying snapshots.
+type SnapshotsOpts struct {
+	Filter *filters.Filter
+	Opts   types.Store
 }
 
 // StorageExecutor is the client-side functionality for a StorageDriver.
@@ -67,6 +75,10 @@ always return ErrResourceNotFound if the acted upon resource cannot be found.
 */
 type StorageDriver interface {
 	StorageExecutor
+
+	// SupportsFilters returns a flag indicating whether or not the backend
+	// storage platform supports filtered results.
+	SupportsFilters() bool
 
 	// NextDeviceInfo returns the information about the driver's next available
 	// device workflow.
@@ -143,7 +155,9 @@ type StorageDriver interface {
 	**                             Snapshots                                  **
 	***************************************************************************/
 	// Snapshots returns all volumes or a filtered list of snapshots.
-	Snapshots(ctx context.Context, opts types.Store) ([]*types.Snapshot, error)
+	Snapshots(
+		ctx context.Context,
+		opts *SnapshotsOpts) ([]*types.Snapshot, error)
 
 	// SnapshotInspect inspects a single snapshot.
 	SnapshotInspect(

--- a/api/types/filters/filters.go
+++ b/api/types/filters/filters.go
@@ -1,0 +1,59 @@
+package filters
+
+// FilterOperator is a filter operator.
+type FilterOperator int
+
+const (
+	// FilterAnd is the & operator.
+	FilterAnd FilterOperator = iota
+
+	// FilterOr is the | operator.
+	FilterOr
+
+	// FilterNot is the ! operator.
+	FilterNot
+
+	// FilterPresent is the =* operator.
+	FilterPresent
+
+	// FilterEqualityMatch is the = operator.
+	FilterEqualityMatch
+
+	// FilterSubstrings is the = operator in conjunction with a string that
+	// has leading and trailing * characters.
+	FilterSubstrings
+
+	// FilterSubstringsPrefix is the = operator in conjunction with a string
+	// that has a leading * character.
+	FilterSubstringsPrefix
+
+	// FilterSubstringsPostfix is the = operator in conjunction with a string
+	// that has a trailing * character.
+	FilterSubstringsPostfix
+
+	// FilterGreaterOrEqual is the >= operator.
+	FilterGreaterOrEqual
+
+	// FilterLessOrEqual is the <= operator.
+	FilterLessOrEqual
+
+	// FilterApproxMatch is the ~= operator.
+	FilterApproxMatch
+)
+
+// Filter is an LDAP-style filter string.
+type Filter struct {
+
+	// Op is the operation.
+	Op FilterOperator
+
+	// Children is a list of any sub-filters if this filter is a compound
+	// filter.
+	Children []*Filter
+
+	// Left is the left operand.
+	Left string
+
+	// Right is the right operand.
+	Right string
+}

--- a/api/utils/filters/filters.go
+++ b/api/utils/filters/filters.go
@@ -1,0 +1,201 @@
+/*
+Package filters is a piece of thievery as the LDAP filter parsing code was
+lifted serepticiously from
+https://github.com/tonnerre/go-ldap/blob/master/ldap.go. The code was reused
+this way as opposed to imports in order to modify it heavily for the needs of
+the project.
+*/
+package filters
+
+import (
+	"bytes"
+	"net/url"
+
+	"github.com/akutz/goof"
+
+	"github.com/emccode/libstorage/api/types/filters"
+)
+
+const (
+	filterAnd               = filters.FilterAnd
+	filterOr                = filters.FilterOr
+	filterNot               = filters.FilterNot
+	filterPresent           = filters.FilterPresent
+	filterEqualityMatch     = filters.FilterEqualityMatch
+	filterSubstrings        = filters.FilterSubstrings
+	filterSubstringsPrefix  = filters.FilterSubstringsPrefix
+	filterSubstringsPostfix = filters.FilterSubstringsPostfix
+	filterGreaterOrEqual    = filters.FilterGreaterOrEqual
+	filterLessOrEqual       = filters.FilterLessOrEqual
+	filterApproxMatch       = filters.FilterApproxMatch
+)
+
+var filterMap = map[filters.FilterOperator]string{
+	filterAnd:            "And",
+	filterOr:             "Or",
+	filterNot:            "Not",
+	filterEqualityMatch:  "Equality Match",
+	filterSubstrings:     "Substrings",
+	filterGreaterOrEqual: "Greater Or Equal",
+	filterLessOrEqual:    "Less Or Equal",
+	filterPresent:        "Present",
+	filterApproxMatch:    "Approx Match",
+}
+
+var (
+	errCharZeroNotLParen = goof.New("filter does not start with an '()'")
+	errUnexpectedEOF     = goof.New("unexpected end of filter")
+	errCompile           = goof.New("error compiling filter")
+	errParse             = goof.New("error parsing filter")
+)
+
+// CompileFilter compiles a filter string.
+func CompileFilter(s string) (*filters.Filter, error) {
+
+	es, err := url.QueryUnescape(s)
+	if err != nil {
+		return nil, err
+	}
+	s = es
+
+	if len(s) == 0 || s[0] != '(' {
+		return nil, errCharZeroNotLParen
+	}
+
+	f, pos, err := compileFilter(s, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	if pos != len(s) {
+		return nil, goof.WithField(
+			"extra", s[pos:],
+			"finished compiling filter with extra at end")
+	}
+
+	return f, nil
+}
+
+func compileFilterSet(
+	s string, pos int, parent *filters.Filter) (int, error) {
+
+	for pos < len(s) && s[pos] == '(' {
+		child, newPos, err := compileFilter(s, pos+1)
+		if err != nil {
+			return pos, err
+		}
+		pos = newPos
+		parent.Children = append(parent.Children, child)
+	}
+
+	if pos == len(s) {
+		return pos, errUnexpectedEOF
+	}
+
+	return pos + 1, nil
+}
+
+func compileFilter(s string, pos int) (*filters.Filter, int, error) {
+
+	switch s[pos] {
+	case '(':
+		f, newPos, err := compileFilter(s, pos+1)
+		newPos++
+		return f, newPos, err
+
+	case '&':
+		f := &filters.Filter{Op: filterAnd}
+		newPos, err := compileFilterSet(s, pos+1, f)
+		return f, newPos, err
+
+	case '|':
+		f := &filters.Filter{Op: filterOr}
+		newPos, err := compileFilterSet(s, pos+1, f)
+		return f, newPos, err
+
+	case '!':
+		f := &filters.Filter{Op: filterNot}
+		child, newPos, err := compileFilter(s, pos+1)
+		f.Children = append(f.Children, child)
+		return f, newPos, err
+
+	default:
+
+		var (
+			f          *filters.Filter
+			abuf, cbuf bytes.Buffer
+			newPos     = pos
+		)
+
+		for newPos < len(s) && s[newPos] != ')' {
+			switch {
+			case f != nil:
+				if err := cbuf.WriteByte(s[newPos]); err != nil {
+					return nil, 0, err
+				}
+
+			case s[newPos] == '=':
+				f = &filters.Filter{Op: filterEqualityMatch}
+
+			case s[newPos] == '>' && s[newPos+1] == '=':
+				f = &filters.Filter{Op: filterGreaterOrEqual}
+				newPos++
+
+			case s[newPos] == '<' && s[newPos+1] == '=':
+				f = &filters.Filter{Op: filterLessOrEqual}
+				newPos++
+
+			case s[newPos] == '~' && s[newPos+1] == '=':
+				f = &filters.Filter{Op: filterApproxMatch}
+				newPos++
+
+			case f == nil:
+				if err := abuf.WriteByte(s[newPos]); err != nil {
+					return nil, 0, err
+				}
+			}
+			newPos++
+		}
+
+		if newPos == len(s) {
+			return f, newPos, errUnexpectedEOF
+		}
+
+		if f == nil {
+			return nil, 0, errParse
+		}
+
+		f.Left = abuf.String()
+
+		var (
+			cbyt = cbuf.Bytes()
+			cstr = cbuf.String()
+			clen = len(cbyt)
+			cfch = cbyt[clen-1]
+		)
+
+		switch {
+		case f.Op == filterEqualityMatch && cstr == "*":
+			f.Op = filterPresent
+
+		case f.Op == filterEqualityMatch &&
+			cbyt[0] == '*' && cfch == '*' && clen > 2:
+			f.Op = filterSubstrings
+			f.Right = cstr[1 : clen-1]
+
+		case f.Op == filterEqualityMatch && cbyt[0] == '*' && clen > 1:
+			f.Op = filterSubstringsPrefix
+			f.Right = cstr[1:]
+
+		case f.Op == filterEqualityMatch && cfch == '*' && clen > 1:
+			f.Op = filterSubstringsPostfix
+			f.Right = cstr[:clen-1]
+
+		default:
+			f.Right = cstr
+
+		}
+		newPos++
+		return f, newPos, nil
+	}
+}

--- a/api/utils/filters/filters_test.go
+++ b/api/utils/filters/filters_test.go
@@ -1,0 +1,147 @@
+package filters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompilePresent(t *testing.T) {
+	f, err := CompileFilter(`(datacenter=*)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterPresent, f.Op)
+	assert.EqualValues(t, "datacenter", f.Left)
+}
+
+func TestCompileSubstring(t *testing.T) {
+	f, err := CompileFilter(`(datacenter=*Texas*)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterSubstrings, f.Op)
+	assert.EqualValues(t, "datacenter", f.Left)
+	assert.EqualValues(t, "Texas", f.Right)
+
+}
+
+func TestCompileSubstringPrefix(t *testing.T) {
+	f, err := CompileFilter(`(datacenter=*Texas)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterSubstringsPrefix, f.Op)
+	assert.EqualValues(t, "datacenter", f.Left)
+	assert.EqualValues(t, "Texas", f.Right)
+}
+
+func TestCompileSubstringPostfix(t *testing.T) {
+	f, err := CompileFilter(`(datacenter=Texas*)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterSubstringsPostfix, f.Op)
+	assert.EqualValues(t, "datacenter", f.Left)
+	assert.EqualValues(t, "Texas", f.Right)
+}
+
+func TestCompileAndEqualityFilter(t *testing.T) {
+	f, err := CompileFilter(`(&(datacenter=irvine)(department=finance))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterAnd, f.Op)
+
+	assert.EqualValues(t, filterEqualityMatch, f.Children[0].Op)
+	assert.EqualValues(t, "datacenter", f.Children[0].Left)
+	assert.EqualValues(t, "irvine", f.Children[0].Right)
+
+	assert.EqualValues(t, filterEqualityMatch, f.Children[1].Op)
+	assert.EqualValues(t, "department", f.Children[1].Left)
+	assert.EqualValues(t, "finance", f.Children[1].Right)
+}
+
+func TestCompileAndEqualityURLEscapedFilter(t *testing.T) {
+	f, err := CompileFilter(`(%26(datacenter=irvine)(department=finance))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterAnd, f.Op)
+
+	assert.EqualValues(t, filterEqualityMatch, f.Children[0].Op)
+	assert.EqualValues(t, "datacenter", f.Children[0].Left)
+	assert.EqualValues(t, "irvine", f.Children[0].Right)
+
+	assert.EqualValues(t, filterEqualityMatch, f.Children[1].Op)
+	assert.EqualValues(t, "department", f.Children[1].Left)
+	assert.EqualValues(t, "finance", f.Children[1].Right)
+}
+
+func TestCompileAndOrEqualityFilter(t *testing.T) {
+	f, err := CompileFilter(
+		`(&(|(datacenter=irvine)(datacenter=houston))(department=finance))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterAnd, f.Op)
+
+	assert.EqualValues(t, filterOr, f.Children[0].Op)
+
+	assert.EqualValues(t, filterEqualityMatch,
+		f.Children[0].Children[0].Op)
+	assert.EqualValues(t, "datacenter",
+		f.Children[0].Children[0].Left)
+	assert.EqualValues(t, "irvine",
+		f.Children[0].Children[0].Right)
+
+	assert.EqualValues(t, filterEqualityMatch,
+		f.Children[0].Children[1].Op)
+	assert.EqualValues(t, "datacenter",
+		f.Children[0].Children[1].Left)
+	assert.EqualValues(t, "houston",
+		f.Children[0].Children[1].Right)
+
+	assert.EqualValues(t, filterEqualityMatch, f.Children[1].Op)
+	assert.EqualValues(t, "department", f.Children[1].Left)
+	assert.EqualValues(t, "finance", f.Children[1].Right)
+}
+
+func TestCompileInequalityMatch(t *testing.T) {
+	f, err := CompileFilter(
+		`(&(|(datacenter=irvine)(!(datacenter=houston)))(department=finance))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterAnd, f.Op)
+
+	assert.EqualValues(t, filterOr, f.Children[0].Op)
+
+	assert.EqualValues(t, filterEqualityMatch,
+		f.Children[0].Children[0].Op)
+	assert.EqualValues(t, "datacenter",
+		f.Children[0].Children[0].Left)
+	assert.EqualValues(t, "irvine",
+		f.Children[0].Children[0].Right)
+
+	assert.EqualValues(t, filterNot, f.Children[0].Children[1].Op)
+
+	assert.EqualValues(t, filterEqualityMatch,
+		f.Children[0].Children[1].Children[0].Op)
+	assert.EqualValues(t, "datacenter",
+		f.Children[0].Children[1].Children[0].Left)
+	assert.EqualValues(t, "houston",
+		f.Children[0].Children[1].Children[0].Right)
+
+	assert.EqualValues(t, filterEqualityMatch, f.Children[1].Op)
+	assert.EqualValues(t, "department", f.Children[1].Left)
+	assert.EqualValues(t, "finance", f.Children[1].Right)
+}

--- a/drivers/storage/mock/mock_driver.go
+++ b/drivers/storage/mock/mock_driver.go
@@ -91,6 +91,10 @@ func (d *driver) Type() types.StorageType {
 	return types.Block
 }
 
+func (d *driver) SupportsFilters() bool {
+	return false
+}
+
 func (d *driver) NextDeviceInfo() *types.NextDeviceInfo {
 	return d.nextDeviceInfo
 }
@@ -281,7 +285,7 @@ func (d *driver) VolumeDetach(
 
 func (d *driver) Snapshots(
 	ctx context.Context,
-	opts types.Store) ([]*types.Snapshot, error) {
+	opts *drivers.SnapshotsOpts) ([]*types.Snapshot, error) {
 
 	return d.snapshots, nil
 }

--- a/drivers/storage/vfs/vfs_driver.go
+++ b/drivers/storage/vfs/vfs_driver.go
@@ -25,6 +25,10 @@ func newDriver() drivers.StorageDriver {
 	return &driver{executor.Executor{}}
 }
 
+func (d *driver) SupportsFilters() bool {
+	return false
+}
+
 func (d *driver) Type() types.StorageType {
 	return types.Object
 }
@@ -103,7 +107,7 @@ func (d *driver) VolumeDetach(
 
 func (d *driver) Snapshots(
 	ctx context.Context,
-	opts types.Store) ([]*types.Snapshot, error) {
+	opts *drivers.SnapshotsOpts) ([]*types.Snapshot, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This patch adds support for parsing ABNF LDAP filter strings in order to support filters via the URL as an argument of the query string argument named "filter".

@dvonthenen, what are your thoughts on this? Notice via the `filters_test.go` file how we actually parse them. I think it would work.