### PR TITLE
InstanceID Test

### DIFF
--- a/cli/servers/libstor-server/libstor-server.go
+++ b/cli/servers/libstor-server/libstor-server.go
@@ -9,7 +9,9 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: libstor-server DRIVER")
+		fmt.Fprintln(
+			os.Stderr,
+			"usage: libstor-server DRIVER [SERVICE] [DRIVER [SERVICE]]...")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This patch adds a test asserting that the process of downloading an executor to generate the instance ID for a client is successful.