### PR TITLE
Refactored Client Interfaces & Enhanced Tests

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -27,11 +27,8 @@ import (
 	"github.com/emccode/libstorage/api/utils"
 )
 
-// Client is the interface for Golang libStorage clients.
+// Client is the base interface for the libStorage API client..
 type Client interface {
-
-	// Root returns a list of root resources.
-	Root() (apihttp.RootResources, error)
 
 	// Services returns a map of the configured Services.
 	Services() (apihttp.ServicesMap, error)
@@ -48,11 +45,20 @@ type Client interface {
 
 	// VolumeCreate creates a single volume.
 	VolumeCreate(
-		service string, request *apihttp.VolumeCreateRequest) (*types.Volume, error)
+		service string,
+		request *apihttp.VolumeCreateRequest) (*types.Volume, error)
 
 	// VolumeRemove removes a single volume.
 	VolumeRemove(
 		service, volumeID string) error
+}
+
+// APIClient is the extended interface for the libStorage API client.
+type APIClient interface {
+	Client
+
+	// Root returns a list of root resources.
+	Root() (apihttp.RootResources, error)
 
 	// Executors returns information about the executors.
 	Executors() (apihttp.ExecutorsMap, error)
@@ -83,7 +89,7 @@ type client struct {
 // property libstorage.host.
 func Dial(
 	ctx context.Context,
-	config gofig.Config) (Client, error) {
+	config gofig.Config) (APIClient, error) {
 
 	c := &client{config: config}
 	c.logRequests = c.config.GetBool(
@@ -183,7 +189,8 @@ func (c *client) VolumeInspect(
 }
 
 func (c *client) VolumeCreate(
-	service string, request *apihttp.VolumeCreateRequest) (*types.Volume, error) {
+	service string,
+	request *apihttp.VolumeCreateRequest) (*types.Volume, error) {
 
 	reply := types.Volume{}
 	if _, err := c.httpPost(

--- a/api/tests/tests_executors.go
+++ b/api/tests/tests_executors.go
@@ -1,0 +1,132 @@
+package tests
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/akutz/gofig"
+	"github.com/stretchr/testify/assert"
+
+	apiclient "github.com/emccode/libstorage/api/client"
+	"github.com/emccode/libstorage/api/types"
+	"github.com/emccode/libstorage/client"
+)
+
+// TestExecutors tests the GET /executors route.
+var TestExecutors = func(
+	config gofig.Config,
+	client client.Client, t *testing.T) {
+
+	reply, err := client.(apiclient.APIClient).Executors()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLSXWindows(t, reply["lsx-windows.exe"])
+	assertLSXLinux(t, reply["lsx-linux"])
+	assertLSXDarwin(t, reply["lsx-darwin"])
+}
+
+// TestHeadExecutorWindows tests the HEAD /executors/lsx-windows.exe route.
+var TestHeadExecutorWindows = func(
+	config gofig.Config,
+	client client.Client, t *testing.T) {
+
+	reply, err := client.(apiclient.APIClient).ExecutorHead("lsx-windows.exe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLSXWindows(t, reply)
+}
+
+// TestHeadExecutorLinux tests the HEAD /executors/lsx-linux route.
+var TestHeadExecutorLinux = func(
+	config gofig.Config,
+	client client.Client, t *testing.T) {
+
+	reply, err := client.(apiclient.APIClient).ExecutorHead("lsx-linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLSXLinux(t, reply)
+}
+
+// TestHeadExecutorDarwin tests the HEAD /executors/lsx-darwin route.
+var TestHeadExecutorDarwin = func(
+	config gofig.Config,
+	client client.Client, t *testing.T) {
+
+	reply, err := client.(apiclient.APIClient).ExecutorHead("lsx-darwin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLSXDarwin(t, reply)
+}
+
+// TestGetExecutorWindows tests the GET /executors/lsx-windows.exe route.
+var TestGetExecutorWindows = func(
+	config gofig.Config,
+	client client.Client, t *testing.T) {
+
+	reply, err := client.(apiclient.APIClient).ExecutorGet("lsx-windows.exe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reply.Close()
+	buf, err := ioutil.ReadAll(reply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.EqualValues(t, lsxWindowsInfo.Size, len(buf))
+}
+
+// TestGetExecutorLinux tests the GET /executors/lsx-linux route.
+var TestGetExecutorLinux = func(
+	config gofig.Config,
+	client client.Client, t *testing.T) {
+
+	reply, err := client.(apiclient.APIClient).ExecutorGet("lsx-linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reply.Close()
+	buf, err := ioutil.ReadAll(reply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.EqualValues(t, lsxLinuxInfo.Size, len(buf))
+}
+
+// TestGetExecutorDarwin tests the GET /executors/lsx-darwin route.
+var TestGetExecutorDarwin = func(
+	config gofig.Config,
+	client client.Client, t *testing.T) {
+
+	reply, err := client.(apiclient.APIClient).ExecutorGet("lsx-darwin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reply.Close()
+	buf, err := ioutil.ReadAll(reply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.EqualValues(t, lsxDarwinInfo.Size, len(buf))
+}
+
+func assertLSXWindows(t *testing.T, i *types.ExecutorInfo) {
+	assert.Equal(t, lsxWindowsInfo.Name, i.Name)
+	assert.EqualValues(t, lsxWindowsInfo.Size, i.Size)
+	assert.Equal(t, lsxWindowsInfo.MD5Checksum, i.MD5Checksum)
+}
+
+func assertLSXLinux(t *testing.T, i *types.ExecutorInfo) {
+	assert.Equal(t, lsxLinuxInfo.Name, i.Name)
+	assert.EqualValues(t, lsxLinuxInfo.Size, i.Size)
+	assert.Equal(t, lsxLinuxInfo.MD5Checksum, i.MD5Checksum)
+}
+
+func assertLSXDarwin(t *testing.T, i *types.ExecutorInfo) {
+	assert.Equal(t, lsxDarwinInfo.Name, i.Name)
+	assert.EqualValues(t, lsxDarwinInfo.Size, i.Size)
+	assert.Equal(t, lsxDarwinInfo.MD5Checksum, i.MD5Checksum)
+}

--- a/api/tests/tests_std.go
+++ b/api/tests/tests_std.go
@@ -1,0 +1,69 @@
+package tests
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/akutz/gofig"
+	"github.com/akutz/gotil"
+	"github.com/stretchr/testify/assert"
+
+	apiclient "github.com/emccode/libstorage/api/client"
+	"github.com/emccode/libstorage/api/types"
+	"github.com/emccode/libstorage/client"
+)
+
+// TestRoot tests the GET / route.
+var TestRoot = func(config gofig.Config, client client.Client, t *testing.T) {
+	reply, err := client.(apiclient.APIClient).Root()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, len(reply), 5)
+}
+
+// InstanceIDTest is the test harness for testing the instance ID.
+type InstanceIDTest struct {
+
+	// Driver is the name of the driver/executor for which to get the instance
+	// ID.
+	Driver string
+
+	// Expected is the expected instance ID value.
+	Expected *types.InstanceID
+}
+
+// Test is the APITestFunc for the InstanceIDTest.
+func (idt *InstanceIDTest) Test(
+	config gofig.Config,
+	client client.Client,
+	t *testing.T) {
+
+	expectedBuf, err := json.Marshal(idt.Expected)
+	assert.NoError(t, err)
+	expectedJSON := string(expectedBuf)
+
+	reply, err := client.(apiclient.APIClient).ExecutorGet(lsxbin)
+	assert.NoError(t, err)
+	defer reply.Close()
+
+	f, err := ioutil.TempFile("", "")
+	assert.NoError(t, err)
+
+	_, err = io.Copy(f, reply)
+	assert.NoError(t, err)
+
+	err = f.Close()
+	assert.NoError(t, err)
+
+	os.Chmod(f.Name(), 0755)
+
+	out, err := exec.Command(
+		f.Name(), idt.Driver, "instanceID").CombinedOutput()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedJSON, gotil.Trim(string(out)))
+}

--- a/c/libstor-c/libstor-c_exported.go
+++ b/c/libstor-c/libstor-c_exported.go
@@ -57,7 +57,7 @@ func volumes(clientID C.h, attachments C.short) C.result {
 		return result
 	}
 
-	svcToVolMap, err := c.Volumes(attachments > 0)
+	svcToVolMap, err := c.Volumes()
 	if err != nil {
 		result.err = C.CString(err.Error())
 		return result

--- a/client/client.go
+++ b/client/client.go
@@ -7,8 +7,6 @@ import (
 	"github.com/akutz/gotil"
 
 	apiclient "github.com/emccode/libstorage/api/client"
-	"github.com/emccode/libstorage/api/types"
-	apihttp "github.com/emccode/libstorage/api/types/http"
 
 	// load the drivers
 	_ "github.com/emccode/libstorage/drivers/os"
@@ -20,32 +18,12 @@ var (
 
 // Client is the libStorage client.
 type Client interface {
-
-	// Services returns a map of the configured Services.
-	Services() (apihttp.ServicesMap, error)
-
-	// ServiceInspect returns information about a service.
-	ServiceInspect(name string) (*types.ServiceInfo, error)
-
-	// Volumes returns all volumes for all configured services.
-	Volumes(attachments bool) (apihttp.ServiceVolumeMap, error)
-
-	// VolumeInspect gets information about a single volume.
-	VolumeInspect(
-		service, volumeID string, attachments bool) (*types.Volume, error)
-
-	// VolumeCreate creates a single volume.
-	VolumeCreate(
-		service string, request *apihttp.VolumeCreateRequest) (*types.Volume, error)
-
-	// VolumeRemove removes a single volume.
-	VolumeRemove(
-		service, volumeID string) error
+	apiclient.Client
 }
 
 type client struct {
+	apiclient.APIClient
 	config gofig.Config
-	apicli apiclient.Client
 }
 
 // New returns a new Client.
@@ -57,39 +35,11 @@ func New(config gofig.Config) (Client, error) {
 			config = cfg
 		}
 	}
-	apicli, err := apiclient.Dial(nil, config)
+	ac, err := apiclient.Dial(nil, config)
 	if err != nil {
 		return nil, err
 	}
-	return &client{config: config, apicli: apicli}, nil
-}
-
-func (c *client) Services() (apihttp.ServicesMap, error) {
-	return c.apicli.Services()
-}
-
-func (c *client) ServiceInspect(service string) (*types.ServiceInfo, error) {
-	return c.apicli.ServiceInspect(service)
-}
-
-func (c *client) Volumes(
-	attachments bool) (apihttp.ServiceVolumeMap, error) {
-	return c.apicli.Volumes()
-}
-
-func (c *client) VolumeInspect(
-	service, volumeID string, attachments bool) (*types.Volume, error) {
-	return c.apicli.VolumeInspect(service, volumeID, attachments)
-}
-
-func (c *client) VolumeCreate(
-	service string, request *apihttp.VolumeCreateRequest) (*types.Volume, error) {
-	return c.apicli.VolumeCreate(service, request)
-}
-
-func (c *client) VolumeRemove(
-	service, volumeID string) error {
-	return c.apicli.VolumeRemove(service, volumeID)
+	return &client{APIClient: ac, config: config}, nil
 }
 
 func getNewConfig() (gofig.Config, error) {

--- a/drivers/storage/mock/executor/mock_executor.go
+++ b/drivers/storage/mock/executor/mock_executor.go
@@ -39,7 +39,7 @@ func newExecutor() drivers.StorageExecutor {
 func NewExecutor() *Executor {
 	return &Executor{
 		name:       Name,
-		instanceID: getInstanceID(),
+		instanceID: GetInstanceID(),
 	}
 }
 
@@ -73,7 +73,8 @@ func (d *Executor) LocalDevices(
 	return nil, nil
 }
 
-func getInstanceID() *types.InstanceID {
+// GetInstanceID gets the mock instance ID.
+func GetInstanceID() *types.InstanceID {
 	return &types.InstanceID{
 		ID:       "12345",
 		Metadata: instanceIDMetadata(),

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -5,29 +5,16 @@ import (
 
 	"github.com/akutz/gofig"
 
-	apiclient "github.com/emccode/libstorage/api/client"
 	apitests "github.com/emccode/libstorage/api/tests"
+	"github.com/emccode/libstorage/client"
 
 	// load the driver
 	"github.com/emccode/libstorage/drivers/storage/vfs"
 )
 
-func TestRoot(t *testing.T) {
-
-	tf := func(config gofig.Config, client apiclient.Client, t *testing.T) {
-		reply, err := client.Root()
-		if err != nil {
-			t.Fatal(err)
-		}
-		apitests.LogAsJSON(reply, t)
-	}
-
-	apitests.Run(t, vfs.Name, nil, tf)
-}
-
 func TestVolumes(t *testing.T) {
 
-	tf := func(config gofig.Config, client apiclient.Client, t *testing.T) {
+	tf := func(config gofig.Config, client client.Client, t *testing.T) {
 		reply, err := client.Volumes()
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This patch refactors the Client interfaces such that `./api/client` now has the `Client` interface which is the base for the `./client/Client` and `./api/client/APIClient` interfaces. 

The `./api/client/APIClient` interface is what the `./api/client/Client` interface used to be. The `./client/Client` interface is a superset of the `./api/client/Client` functions with the addition of helper functions. However, the `./client/Client` object returned by the `NewClient` function can be cast to `./api/client/APIClient` when it's necessary to access underlying, advanced API functions.

Finally the test harness has been enhanced to provided canned test routines for testing executors, getting the instance ID, and validating common API routes.