### PR TITLE
Fix for initializing Executors

### DIFF
--- a/api/utils/config/config.go
+++ b/api/utils/config/config.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/akutz/gofig"
+	"github.com/akutz/gotil"
+	"github.com/emccode/libstorage/api/utils/paths"
+)
+
+// NewConfig returns a new configuration instance.
+func NewConfig() (gofig.Config, error) {
+	config := gofig.New()
+
+	etcYML := fmt.Sprintf("%s/config.yml", paths.EtcDirPath())
+	usrYML := fmt.Sprintf("%s/config.yml", paths.UsrDirPath)
+
+	etcYAML := fmt.Sprintf("%s/config.yaml", paths.EtcDirPath())
+	usrYAML := fmt.Sprintf("%s/config.yaml", paths.UsrDirPath)
+
+	if err := readConfigFile(config, etcYML); err != nil {
+		return nil, err
+	}
+	if err := readConfigFile(config, etcYAML); err != nil {
+		return nil, err
+	}
+	if err := readConfigFile(config, usrYML); err != nil {
+		return nil, err
+	}
+	if err := readConfigFile(config, usrYAML); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func readConfigFile(config gofig.Config, path string) error {
+	if !gotil.FileExists(path) {
+		return nil
+	}
+	return config.ReadConfigFile(path)
+}

--- a/api/utils/paths/paths.go
+++ b/api/utils/paths/paths.go
@@ -1,0 +1,102 @@
+package paths
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/akutz/gotil"
+)
+
+var (
+	logDirPathSuffix = "/var/log/libstor"
+	etcDirPathSuffix = "/etc/libstor"
+
+	// UsrDirPath is the path to the user libStorage config directory.
+	UsrDirPath = fmt.Sprintf("%s/.libstor", gotil.HomeDir())
+)
+
+var (
+	thisExeDir     string
+	thisExeName    string
+	thisExeAbsPath string
+
+	prefix string
+
+	logDirPath string
+	etcDirPath string
+)
+
+func init() {
+	prefix = os.Getenv("LIBSTORAGE_HOME")
+	thisExeDir, thisExeName, thisExeAbsPath = gotil.GetThisPathParts()
+}
+
+// GetPrefix gets the root path to the libStorage data.
+func GetPrefix() string {
+	return prefix
+}
+
+// Prefix sets the root path to the libStorage data.
+func Prefix(p string) {
+	if p == "" || p == "/" {
+		return
+	}
+
+	logDirPath = ""
+	etcDirPath = ""
+
+	prefix = p
+}
+
+// IsPrefixed returns a flag indicating whether or not a prefix value is set.
+func IsPrefixed() bool {
+	return !(prefix == "" || prefix == "/")
+}
+
+// EtcDirPath returns the path to the REX-Ray etc directory.
+func EtcDirPath() string {
+	if etcDirPath == "" {
+		etcDirPath = fmt.Sprintf("%s%s", prefix, etcDirPathSuffix)
+		os.MkdirAll(etcDirPath, 0755)
+	}
+	return etcDirPath
+}
+
+// LogDirPath returns the path to the log directory.
+func LogDirPath() string {
+	if logDirPath == "" {
+		logDirPath = fmt.Sprintf("%s%s", prefix, logDirPathSuffix)
+		os.MkdirAll(logDirPath, 0755)
+	}
+	return logDirPath
+}
+
+// EtcFilePath returns the path to a file inside the etc directory with the
+// provided file name.
+func EtcFilePath(fileName string) string {
+	return fmt.Sprintf("%s/%s", EtcDirPath(), fileName)
+}
+
+// LogFilePath returns the path to a file inside the log directory with the
+// provided file name.
+func LogFilePath(fileName string) string {
+	return fmt.Sprintf("%s/%s", LogDirPath(), fileName)
+}
+
+// LogFile returns a writer to a file inside the log directory with the
+// provided file name.
+func LogFile(fileName string) (io.Writer, error) {
+	return os.OpenFile(
+		LogFilePath(fileName), os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
+}
+
+// StdOutAndLogFile returns a mutltiplexed writer for the current process's
+// stdout descriptor and alog file with the provided name.
+func StdOutAndLogFile(fileName string) (io.Writer, error) {
+	lf, lfErr := LogFile(fileName)
+	if lfErr != nil {
+		return nil, lfErr
+	}
+	return io.MultiWriter(os.Stdout, lf), nil
+}

--- a/cli/executors/executors.go
+++ b/cli/executors/executors.go
@@ -11,6 +11,7 @@ import (
 	"github.com/emccode/libstorage/api/registry"
 	"github.com/emccode/libstorage/api/types/context"
 	"github.com/emccode/libstorage/api/utils"
+	"github.com/emccode/libstorage/api/utils/config"
 
 	// load the executors
 	//_ "github.com/emccode/libstorage/drivers/storage/ec2/executor"
@@ -40,6 +41,17 @@ func Run() {
 
 	d, err := registry.NewStorageExecutor(args[1])
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	config, err := config.NewConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := d.Init(config); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/akutz/gotil"
 
 	apiclient "github.com/emccode/libstorage/api/client"
+	apiconfig "github.com/emccode/libstorage/api/utils/config"
 
 	// load the drivers
 	_ "github.com/emccode/libstorage/drivers/os"
@@ -29,7 +30,7 @@ type client struct {
 // New returns a new Client.
 func New(config gofig.Config) (Client, error) {
 	if config == nil {
-		if cfg, err := getNewConfig(); err != nil {
+		if cfg, err := apiconfig.NewConfig(); err != nil {
 			return nil, err
 		} else {
 			config = cfg
@@ -40,19 +41,4 @@ func New(config gofig.Config) (Client, error) {
 		return nil, err
 	}
 	return &client{APIClient: ac, config: config}, nil
-}
-
-func getNewConfig() (gofig.Config, error) {
-	cfp := fmt.Sprintf("%s/config.yaml", libstorHome)
-	if !gotil.FileExists(cfp) {
-		cfp = fmt.Sprintf("%s/config.yml", libstorHome)
-		if !gotil.FileExists(cfp) {
-			return gofig.New(), nil
-		}
-	}
-	config := gofig.New()
-	if err := config.ReadConfigFile(cfp); err != nil {
-		return nil, err
-	}
-	return config, nil
 }


### PR DESCRIPTION
This patch fixes an issue where executors were not being initialized with a valid gofig.Config instance.