### PR TITLE
Added ability to query volumes by service

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -43,6 +43,9 @@ type Client interface {
 	// Volumes returns a list of all Volumes for all Services.
 	Volumes() (apihttp.ServiceVolumeMap, error)
 
+	// VolumesByService returns a list of all Volumes for a service.
+	VolumesByService(service string) (apihttp.VolumeMap, error)
+
 	// VolumeInspect gets information about a single volume.
 	VolumeInspect(
 		service, volumeID string, attachments bool) (*types.Volume, error)
@@ -213,6 +216,16 @@ func (c *client) ServiceSnapshots(
 func (c *client) Volumes() (apihttp.ServiceVolumeMap, error) {
 	reply := apihttp.ServiceVolumeMap{}
 	if _, err := c.httpGet("/volumes", &reply); err != nil {
+		return nil, err
+	}
+	return reply, nil
+}
+
+func (c *client) VolumesByService(
+	service string) (apihttp.VolumeMap, error) {
+	reply := apihttp.VolumeMap{}
+	if _, err := c.httpGet(
+		fmt.Sprintf("/volumes/%s", service), &reply); err != nil {
 		return nil, err
 	}
 	return reply, nil

--- a/drivers/storage/mock/tests/mock_test.go
+++ b/drivers/storage/mock/tests/mock_test.go
@@ -108,6 +108,20 @@ func TestVolumes(t *testing.T) {
 	apitests.Run(t, mock.Name, configYAML, tf)
 }
 
+func TestVolumesByService(t *testing.T) {
+	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+		reply, err := client.VolumesByService("mock")
+		if err != nil {
+			t.Fatal(err)
+		}
+		apitests.LogAsJSON(reply, t)
+		_, ok := reply["vol-000"]
+		assert.Equal(t, ok, true)
+		assert.Equal(t, reply["vol-000"].AvailabilityZone, "zone-000")
+	}
+	apitests.Run(t, mock.Name, configYAML, tf)
+}
+
 func TestVolumeCreate(t *testing.T) {
 
 	tf := func(config gofig.Config, client client.Client, t *testing.T) {


### PR DESCRIPTION
This commit introduces the ability to query for all volumes from
a given service name.