### PR TITLE
Added volume snapshot functionality to the client

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -51,6 +51,13 @@ type Client interface {
 	// VolumeRemove removes a single volume.
 	VolumeRemove(
 		service, volumeID string) error
+
+	// VolumeSnapshot creates a single snapshot.
+	VolumeSnapshot(
+		service string,
+		volumeID string,
+		request *apihttp.VolumeSnapshotRequest) (*types.Snapshot, error)
+
 }
 
 // APIClient is the extended interface for the libStorage API client.
@@ -208,6 +215,19 @@ func (c *client) VolumeRemove(
 		return err
 	}
 	return nil
+}
+
+func (c *client) VolumeSnapshot(
+	service string,
+	volumeID string,
+	request *apihttp.VolumeSnapshotRequest) (*types.Snapshot, error) {
+
+	reply := types.Snapshot{}
+	if _, err := c.httpPost(
+		fmt.Sprintf("/volumes/%s/%s?snapshot", service, volumeID), request, &reply); err != nil {
+		return nil, err
+	}
+	return &reply, nil
 }
 
 func (c *client) Executors() (apihttp.ExecutorsMap, error) {

--- a/api/server/router/volume/volume.go
+++ b/api/server/router/volume/volume.go
@@ -142,6 +142,7 @@ func (r *router) initRoutes() {
 				schema.VolumeSnapshotRequestSchema,
 				schema.SnapshotSchema,
 				func() interface{} { return &apihttp.VolumeSnapshotRequest{} }),
+			handlers.NewPostArgsHandler(),
 		).Queries("snapshot"),
 
 		// attach an existing volume

--- a/api/utils/schema/schema.go
+++ b/api/utils/schema/schema.go
@@ -117,6 +117,15 @@ func ValidateVolumeCreateRequest(
 	return validateObject(VolumeCreateRequestSchema, v)
 }
 
+// ValidateVolumeSnapshotRequest validates a VolumeSnapshotRequest object using the
+// JSON schema. If the object is valid no error is returned. The first return
+// value, the object marshaled to JSON, is returned whether or not the
+// validation is successful.
+func ValidateVolumeSnapshotRequest(
+	v *httptypes.VolumeSnapshotRequest) ([]byte, error) {
+	return validateObject(VolumeSnapshotRequestSchema, v)
+}
+
 func validateObject(s []byte, o interface{}) (d []byte, e error) {
 	if d, e = json.Marshal(o); e != nil {
 		return

--- a/api/utils/schema/schema_test.go
+++ b/api/utils/schema/schema_test.go
@@ -256,3 +256,22 @@ func TestVolumeCreateRequestObject(t *testing.T) {
 		assert.NoError(t, err)
 	}
 }
+
+func TestVolumeSnapshotRequestObject(t *testing.T) {
+	snapshotName := "snapshot1"
+	opts := map[string]interface{}{
+		"priority": 2,
+	}
+
+	s := &httptypes.VolumeSnapshotRequest{
+		SnapshotName: snapshotName,
+		Opts: opts,
+	}
+
+	d, err := ValidateVolumeSnapshotRequest(s)
+	if d == nil {
+		assert.NoError(t, err, string(d))
+	} else {
+		assert.NoError(t, err)
+	}
+}

--- a/drivers/storage/mock/tests/mock_test.go
+++ b/drivers/storage/mock/tests/mock_test.go
@@ -144,6 +144,43 @@ func TestVolumeRemove(t *testing.T) {
 	apitests.Run(t, mock.Name, configYAML, tf)
 }
 
+func TestVolumeSnapshot(t *testing.T) {
+
+	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+		volumeID := "vol-000"
+		snapshotName := "snapshot1"
+		opts := map[string]interface{}{
+			"priority": 2,
+		}
+
+		request := &apihttp.VolumeSnapshotRequest{
+			SnapshotName: snapshotName,
+			Opts: opts,
+		}
+
+		reply, err := client.VolumeSnapshot("mock", volumeID,request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		apitests.LogAsJSON(reply, t)
+
+		assert.Equal(t, snapshotName, reply.Name)
+		assert.Equal(t, volumeID, reply.VolumeID)
+
+	}
+	apitests.Run(t, mock.Name, configYAML, tf)
+}
+
+func TestSnapshotRemove(t *testing.T) {
+	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+		err := client.VolumeRemove("mock", "vol-000")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	apitests.Run(t, mock.Name, configYAML, tf)
+}
+
 func TestExecutors(t *testing.T) {
 	apitests.Run(t, mock.Name, configYAML, apitests.TestExecutors)
 }


### PR DESCRIPTION
This commit introduces the ability to create snapshots from
volumes at the client layer.