### PR TITLE
VFS Driver Work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,6 +407,11 @@ $(C_LIBSTOR_C_SO):  $(C_LIBSTOR_C_SO_SRCS) \
 					$(C_LIBSTOR_C_GO_DEPS)
 	go build -buildmode=c-shared -o $@ $(C_LIBSTOR_C_DIR)
 
+$(C_LIBSTOR_C_SO)-clean:
+	rm -f $(C_LIBSTOR_C_SO) $(basename $(C_LIBSTOR_C_SO).h)
+GO_PHONY += $(C_LIBSTOR_C_SO)-clean
+GO_CLEAN += $(C_LIBSTOR_C_SO)-clean
+
 $(C_LIBSTOR_C_BIN): $(C_LIBSTOR_C_BIN_SRC) \
 					$(C_LIBSTOR_C_SO) \
 					$(C_LIBSTOR_C_GO_DEPS)
@@ -416,6 +421,12 @@ $(C_LIBSTOR_C_BIN): $(C_LIBSTOR_C_BIN_SRC) \
 		-o $@ \
 		$(C_LIBSTOR_C_BIN_SRC) \
 		-lstor-c
+
+$(C_LIBSTOR_C_BIN)-clean:
+	rm -f $(C_LIBSTOR_C_BIN)
+GO_PHONY += $(C_LIBSTOR_C_BIN)-clean
+GO_CLEAN += $(C_LIBSTOR_C_BIN)-clean
+
 
 ################################################################################
 ##                                  C SERVER                                  ##
@@ -433,6 +444,11 @@ $(C_LIBSTOR_S_SO):	$(C_LIBSTOR_TYPES_H) \
 					$(C_LIBSTOR_S_SO_SRCS)
 	go build -buildmode=c-shared -o $@ $(C_LIBSTOR_S_DIR)
 
+$(C_LIBSTOR_S_SO)-clean:
+	rm -f $(C_LIBSTOR_S_SO) $(basename $(C_LIBSTOR_S_SO).h)
+GO_PHONY += $(C_LIBSTOR_S_SO)-clean
+GO_CLEAN += $(C_LIBSTOR_S_SO)-clean
+
 $(C_LIBSTOR_S_BIN): $(C_LIBSTOR_TYPES_H) \
 					$(C_LIBSTOR_S_BIN_SRC) \
 					$(C_LIBSTOR_S_SO) \
@@ -444,6 +460,11 @@ $(C_LIBSTOR_S_BIN): $(C_LIBSTOR_TYPES_H) \
 		$(C_LIBSTOR_S_BIN_SRC) \
 		-lstor-s
 
+$(C_LIBSTOR_S_BIN)-clean:
+	rm -f $(C_LIBSTOR_S_BIN)
+GO_PHONY += $(C_LIBSTOR_S_BIN)-clean
+GO_CLEAN += $(C_LIBSTOR_S_BIN)-clean
+
 ################################################################################
 ##                                  TARGETS                                   ##
 ################################################################################
@@ -452,7 +473,8 @@ build-tests: $(GO_BUILD_TESTS)
 
 build-executors: $(EXECUTORS_EMBEDDED)
 
-build: $(GO_BUILD) libstor-c libstor-s
+build: $(GO_BUILD)
+	$(MAKE) -j libstor-c libstor-s
 
 test: $(GO_TEST)
 

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -280,6 +280,14 @@ func (c *client) httpDo(
 	}
 	c.logResponse(res)
 
+	if res.StatusCode > 299 {
+		je := &types.JSONError{}
+		if err := json.NewDecoder(res.Body).Decode(je); err != nil {
+			return res, goof.WithField("status", res.StatusCode, "http error")
+		}
+		return res, je
+	}
+
 	if req.Method != http.MethodHead && reply != nil {
 		if err := decRes(res.Body, reply); err != nil {
 			return nil, err

--- a/api/registry/registry.go
+++ b/api/registry/registry.go
@@ -16,7 +16,7 @@ var (
 	storExecsCtors    = map[string]drivers.NewStorageExecutor{}
 	storExecsCtorsRWL = &sync.RWMutex{}
 
-	storDriverCtors    = map[string]drivers.NewStorageDriver{}
+	storDriverCtors    = map[string]drivers.NewRemoteStorageDriver{}
 	storDriverCtorsRWL = &sync.RWMutex{}
 
 	osDriverCtors    = map[string]drivers.NewOSDriver{}
@@ -43,8 +43,8 @@ func RegisterStorageExecutor(name string, ctor drivers.NewStorageExecutor) {
 	storExecsCtors[strings.ToLower(name)] = ctor
 }
 
-// RegisterStorageDriver registers a StorageDriver.
-func RegisterStorageDriver(name string, ctor drivers.NewStorageDriver) {
+// RegisterRemoteStorageDriver registers a RemoteStorageDriver.
+func RegisterRemoteStorageDriver(name string, ctor drivers.NewRemoteStorageDriver) {
 	storDriverCtorsRWL.Lock()
 	defer storDriverCtorsRWL.Unlock()
 	storDriverCtors[strings.ToLower(name)] = ctor
@@ -84,12 +84,12 @@ func NewStorageExecutor(name string) (drivers.StorageExecutor, error) {
 	return ctor(), nil
 }
 
-// NewStorageDriver returns a new instance of the driver specified by the
+// NewRemoteStorageDriver returns a new instance of the driver specified by the
 // driver name.
-func NewStorageDriver(name string) (drivers.StorageDriver, error) {
+func NewRemoteStorageDriver(name string) (drivers.RemoteStorageDriver, error) {
 
 	var ok bool
-	var ctor drivers.NewStorageDriver
+	var ctor drivers.NewRemoteStorageDriver
 
 	func() {
 		storDriverCtorsRWL.RLock()
@@ -159,10 +159,10 @@ func StorageExecutors() <-chan drivers.StorageExecutor {
 	return c
 }
 
-// StorageDrivers returns a channel on which new instances of all registered
+// RemoteStorageDrivers returns a channel on which new instances of all registered
 // storage drivers can be received.
-func StorageDrivers() <-chan drivers.StorageDriver {
-	c := make(chan drivers.StorageDriver)
+func RemoteStorageDrivers() <-chan drivers.RemoteStorageDriver {
+	c := make(chan drivers.RemoteStorageDriver)
 	go func() {
 		storDriverCtorsRWL.RLock()
 		defer storDriverCtorsRWL.RUnlock()

--- a/api/server/handlers/handlers_errors.go
+++ b/api/server/handlers/handlers_errors.go
@@ -42,9 +42,9 @@ func (h *errorHandler) Handle(
 	ctx.Log().Error(err)
 
 	jsonError := types.JSONError{
-		Status:  getStatus(err),
-		Message: err.Error(),
-		Error:   err,
+		Status:     getStatus(err),
+		Message:    err.Error(),
+		InnerError: err,
 	}
 
 	httputils.WriteJSON(w, jsonError.Status, jsonError)

--- a/api/server/handlers/handlers_post_args.go
+++ b/api/server/handlers/handlers_post_args.go
@@ -11,6 +11,7 @@ import (
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/types/context"
 	apihttp "github.com/emccode/libstorage/api/types/http"
+	"github.com/emccode/libstorage/api/utils"
 )
 
 // postArgsHandler is an HTTP filter for injecting the store with the POST
@@ -56,15 +57,11 @@ func (h *postArgsHandler) Handle(
 		case nil:
 			// do nothing
 		case map[string]interface{}:
-			// it's the Opts field; iterate Opts and add them to the store
-			for k, v := range tfv {
-				store.Set(k, v)
-			}
+			store.Set(getFieldName(ft), utils.NewStoreWithData(tfv))
 		default:
 			// add it to the store
 			store.Set(getFieldName(ft), fv)
 		}
-
 	}
 
 	return h.handler(ctx, w, req, store)

--- a/api/server/handlers/handlers_service_validator.go
+++ b/api/server/handlers/handlers_service_validator.go
@@ -43,7 +43,7 @@ func (h *serviceValidator) Handle(
 	}
 
 	serviceName := store.GetString("service")
-	service := services.GetStorageService(serviceName)
+	service := services.GetStorageService(ctx, serviceName)
 	if service == nil {
 		return utils.NewNotFoundError(serviceName)
 	}

--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	serviceTypeName       = utils.GetTypePkgPathAndName((*apisvcs.StorageService)(nil))
-	storageDriverTypeName = utils.GetTypePkgPathAndName((*drivers.StorageDriver)(nil))
+	serviceTypeName             = utils.GetTypePkgPathAndName((*apisvcs.StorageService)(nil))
+	remoteStorageDriverTypeName = utils.GetTypePkgPathAndName((*drivers.RemoteStorageDriver)(nil))
 )
 
 // GetService gets the Service instance from a context.
@@ -33,8 +33,8 @@ func GetService(ctx context.Context) (apisvcs.StorageService, error) {
 	return service, nil
 }
 
-// GetStorageDriver gets the StorageDriver instance from a context.
-func GetStorageDriver(ctx context.Context) (drivers.StorageDriver, error) {
+// GetStorageDriver gets the RemoteStorageDriver instance from a context.
+func GetStorageDriver(ctx context.Context) (drivers.RemoteStorageDriver, error) {
 	service, err := GetService(ctx)
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func WriteTask(
 	timeout := time.NewTimer(time.Second * 60)
 
 	select {
-	case <-services.TaskWaitC(task.ID):
+	case <-services.TaskWaitC(ctx, task.ID):
 		if task.Error != nil {
 			return task.Error
 		}

--- a/api/server/router/service/service_routes.go
+++ b/api/server/router/service/service_routes.go
@@ -18,7 +18,7 @@ func (r *router) servicesList(
 	store types.Store) error {
 
 	var reply apihttp.ServicesMap = map[string]*types.ServiceInfo{}
-	for service := range services.StorageServices() {
+	for service := range services.StorageServices(ctx) {
 		si := toServiceInfo(service)
 		reply[si.Name] = si
 	}

--- a/api/server/router/snapshot/snapshot_routes.go
+++ b/api/server/router/snapshot/snapshot_routes.go
@@ -27,7 +27,7 @@ func (r *router) snapshots(
 		reply   apihttp.ServiceSnapshotMap = map[string]apihttp.SnapshotMap{}
 	)
 
-	for service := range services.StorageServices() {
+	for service := range services.StorageServices(ctx) {
 
 		run := func(
 			ctx context.Context,
@@ -52,7 +52,7 @@ func (r *router) snapshots(
 
 	run := func(ctx context.Context) (interface{}, error) {
 
-		services.TaskWaitAll(taskIDs...)
+		services.TaskWaitAll(ctx, taskIDs...)
 
 		for k, v := range tasks {
 			if v.Error != nil {

--- a/api/server/router/tasks/task_routes.go
+++ b/api/server/router/tasks/task_routes.go
@@ -18,7 +18,7 @@ func (r *router) tasks(
 	store types.Store) error {
 
 	tasks := map[string]*types.Task{}
-	for t := range services.Tasks() {
+	for t := range services.Tasks(ctx) {
 		tasks[fmt.Sprintf("%d", t.ID)] = t
 	}
 	httputils.WriteJSON(w, http.StatusOK, tasks)
@@ -31,7 +31,7 @@ func (r *router) taskInspect(
 	req *http.Request,
 	store types.Store) error {
 
-	task := services.TaskInspect(store.GetInt("taskID"))
+	task := services.TaskInspect(ctx, store.GetInt("taskID"))
 	if task == nil {
 		return utils.NewNotFoundError(store.GetString("taskID"))
 	}

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -26,7 +26,8 @@ type volumesRoute struct {
 	queryAttachments bool
 }
 
-func (r *volumesRoute) volumes(ctx context.Context,
+func (r *volumesRoute) volumes(
+	ctx context.Context,
 	w http.ResponseWriter,
 	req *http.Request,
 	store types.Store) error {
@@ -42,7 +43,7 @@ func (r *volumesRoute) volumes(ctx context.Context,
 		reply   apihttp.ServiceVolumeMap = map[string]apihttp.VolumeMap{}
 	)
 
-	for service := range services.StorageServices() {
+	for service := range services.StorageServices(ctx) {
 
 		run := func(
 			ctx context.Context,
@@ -71,7 +72,7 @@ func (r *volumesRoute) volumes(ctx context.Context,
 
 	run := func(ctx context.Context) (interface{}, error) {
 
-		services.TaskWaitAll(taskIDs...)
+		services.TaskWaitAll(ctx, taskIDs...)
 
 		for k, v := range tasks {
 			if v.Error != nil {
@@ -340,7 +341,7 @@ func (r *router) volumeDetachAll(
 
 	var reply apihttp.ServiceVolumeMap = map[string]apihttp.VolumeMap{}
 
-	for service := range services.StorageServices() {
+	for service := range services.StorageServices(ctx) {
 
 		run := func(
 			ctx context.Context,
@@ -377,7 +378,7 @@ func (r *router) volumeDetachAll(
 	}
 
 	run := func(ctx context.Context) (interface{}, error) {
-		services.TaskWaitAll(taskIDs...)
+		services.TaskWaitAll(ctx, taskIDs...)
 		for _, v := range tasks {
 			if v.Error != nil {
 				return nil, utils.NewBatchProcessErr(reply, v.Error)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -68,6 +68,7 @@ func newServer(config gofig.Config) (*server, error) {
 	}
 
 	s.ctx = s.ctx.WithContextID("server", s.name)
+	s.ctx = s.ctx.WithValue("server", s.name)
 	s.ctx.Log().Debug("initializing server")
 
 	if err := s.initEndpoints(); err != nil {
@@ -75,7 +76,7 @@ func newServer(config gofig.Config) (*server, error) {
 	}
 	s.ctx.Log().Debug("initialized endpoints")
 
-	if err := services.Init(s.config); err != nil {
+	if err := services.Init(s.ctx, s.config); err != nil {
 		return nil, err
 	}
 	s.ctx.Log().Debug("initialized services")

--- a/api/server/services/services_storage.go
+++ b/api/server/services/services_storage.go
@@ -13,7 +13,7 @@ import (
 
 type storageService struct {
 	name          string
-	driver        drivers.StorageDriver
+	driver        drivers.RemoteStorageDriver
 	config        gofig.Config
 	taskExecQueue chan *task
 }
@@ -44,7 +44,7 @@ func (s *storageService) initStorageDriver() error {
 		}
 	}
 
-	driver, err := registry.NewStorageDriver(driverName)
+	driver, err := registry.NewRemoteStorageDriver(driverName)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (s *storageService) Config() gofig.Config {
 	return s.config
 }
 
-func (s *storageService) Driver() drivers.StorageDriver {
+func (s *storageService) Driver() drivers.RemoteStorageDriver {
 	return s.driver
 }
 

--- a/api/server/services/services_task.go
+++ b/api/server/services/services_task.go
@@ -26,7 +26,7 @@ type task struct {
 }
 
 func newTask(ctx context.Context, schema []byte) *task {
-	t := taskService.taskTrack(ctx)
+	t := getTaskService(ctx).taskTrack(ctx)
 	t.resultSchema = schema
 	t.done = make(chan int)
 	return t

--- a/api/tests/tests_std.go
+++ b/api/tests/tests_std.go
@@ -38,12 +38,12 @@ type InstanceIDTest struct {
 }
 
 // Test is the APITestFunc for the InstanceIDTest.
-func (idt *InstanceIDTest) Test(
+func (tt *InstanceIDTest) Test(
 	config gofig.Config,
 	client client.Client,
 	t *testing.T) {
 
-	expectedBuf, err := json.Marshal(idt.Expected)
+	expectedBuf, err := json.Marshal(tt.Expected)
 	assert.NoError(t, err)
 	expectedJSON := string(expectedBuf)
 
@@ -63,7 +63,88 @@ func (idt *InstanceIDTest) Test(
 	os.Chmod(f.Name(), 0755)
 
 	out, err := exec.Command(
-		f.Name(), idt.Driver, "instanceID").CombinedOutput()
+		f.Name(), tt.Driver, "instanceID").CombinedOutput()
 	assert.NoError(t, err)
+	assert.Equal(t, expectedJSON, gotil.Trim(string(out)))
+}
+
+// NextDeviceTest is the test harness for testing getting the next device.
+type NextDeviceTest struct {
+
+	// Driver is the name of the driver/executor for which to get the next
+	// device.
+	Driver string
+
+	// Expected is the expected next device.
+	Expected string
+}
+
+// Test is the APITestFunc for the NextDeviceTest.
+func (tt *NextDeviceTest) Test(
+	config gofig.Config,
+	client client.Client,
+	t *testing.T) {
+
+	reply, err := client.(apiclient.APIClient).ExecutorGet(lsxbin)
+	assert.NoError(t, err)
+	defer reply.Close()
+
+	f, err := ioutil.TempFile("", "")
+	assert.NoError(t, err)
+
+	_, err = io.Copy(f, reply)
+	assert.NoError(t, err)
+
+	err = f.Close()
+	assert.NoError(t, err)
+
+	os.Chmod(f.Name(), 0755)
+
+	out, err := exec.Command(
+		f.Name(), tt.Driver, "nextDevice").CombinedOutput()
+	assert.NoError(t, err)
+	assert.Equal(t, tt.Expected, gotil.Trim(string(out)))
+}
+
+// LocalDevicesTest is the test harness for testing getting the local devices.
+type LocalDevicesTest struct {
+
+	// Driver is the name of the driver/executor for which to get the local
+	// devices.
+	Driver string
+
+	// Expected is the expected local devices.
+	Expected map[string]string
+}
+
+// Test is the APITestFunc for the LocalDevicesTest.
+func (tt *LocalDevicesTest) Test(
+	config gofig.Config,
+	client client.Client,
+	t *testing.T) {
+
+	expectedBuf, err := json.Marshal(tt.Expected)
+	assert.NoError(t, err)
+	expectedJSON := string(expectedBuf)
+
+	reply, err := client.(apiclient.APIClient).ExecutorGet(lsxbin)
+	assert.NoError(t, err)
+	defer reply.Close()
+
+	f, err := ioutil.TempFile("", "")
+	assert.NoError(t, err)
+
+	_, err = io.Copy(f, reply)
+	assert.NoError(t, err)
+
+	err = f.Close()
+	assert.NoError(t, err)
+
+	os.Chmod(f.Name(), 0755)
+
+	out, err := exec.Command(
+		f.Name(), tt.Driver, "localDevices").CombinedOutput()
+	assert.NoError(t, err)
+
 	assert.Equal(t, expectedJSON, gotil.Trim(string(out)))
 }

--- a/api/types/drivers/drivers_storage.go
+++ b/api/types/drivers/drivers_storage.go
@@ -8,8 +8,13 @@ import (
 // NewStorageExecutor is a function that constructs a new StorageExecutors.
 type NewStorageExecutor func() StorageExecutor
 
-// NewStorageDriver is a function that constructs a new StorageDriver.
-type NewStorageDriver func() StorageDriver
+// NewClientStorageDriver is a function that constructs a new
+// ClientStorageDriver.
+type NewClientStorageDriver func() ClientStorageDriver
+
+// NewRemoteStorageDriver is a function that constructs a new
+// RemoteStorageDriver.
+type NewRemoteStorageDriver func() RemoteStorageDriver
 
 // VolumesOpts are options when inspecting a volume.
 type VolumesOpts struct {
@@ -38,7 +43,8 @@ type VolumeAttachByIDOpts struct {
 	Opts       types.Store
 }
 
-// StorageExecutor is the client-side functionality for a StorageDriver.
+// StorageExecutor is the part of a storage driver that is downloaded at
+// runtime by the libStorage client.
 type StorageExecutor interface {
 	Driver
 
@@ -58,15 +64,185 @@ type StorageExecutor interface {
 		opts types.Store) (map[string]string, error)
 }
 
+// ClientStorageDriver is the client-side storage driver.
+type ClientStorageDriver interface {
+	Driver
+
+	/***************************************************************************
+	**                               Instance                                 **
+	***************************************************************************/
+	// InstanceInspectBefore may return an error, preventing the operation.
+	InstanceInspectBefore(
+		ctx context.Context,
+		opts types.Store) error
+
+	// InstanceInspectAfter provides an opportunity to inspect/mutate the
+	// result.
+	InstanceInspectAfter(
+		ctx context.Context,
+		result *types.Instance)
+
+	/***************************************************************************
+	**                               Volumes                                  **
+	***************************************************************************/
+	// VolumesBefore may return an error, preventing the operation.
+	VolumesBefore(
+		ctx context.Context,
+		opts *VolumesOpts) error
+
+	// VolumesAfter provides an opportunity to inspect/mutate the result.
+	VolumesAfter(
+		ctx context.Context,
+		result []*types.Volume)
+
+	// VolumeInspectBefore may return an error, preventing the operation.
+	VolumeInspectBefore(
+		ctx context.Context,
+		volumeID string,
+		opts *VolumeInspectOpts) (*types.Volume, error)
+
+	// VolumeInspectAfter provides an opportunity to inspect/mutate the result.
+	VolumeInspectAfter(
+		ctx context.Context,
+		result *types.Volume)
+
+	// VolumeCreateBefore may return an error, preventing the operation.
+	VolumeCreateBefore(
+		ctx context.Context,
+		name string,
+		opts *VolumeCreateOpts) (*types.Volume, error)
+
+	// VolumeCreateAfter provides an opportunity to inspect/mutate the result.
+	VolumeCreateAfter(
+		ctx context.Context,
+		result *types.Volume)
+
+	// VolumeCreateFromSnapshotBefore may return an error, preventing the
+	// operation.
+	VolumeCreateFromSnapshotBefore(
+		ctx context.Context,
+		snapshotID, volumeName string,
+		opts types.Store) (*types.Volume, error)
+
+	// VolumeCreateFromSnapshotAfter provides an opportunity to inspect/mutate
+	// the result.
+	VolumeCreateFromSnapshotAfter(
+		ctx context.Context,
+		result *types.Volume)
+
+	// VolumeCopyBefore may return an error, preventing the operation.
+	VolumeCopyBefore(
+		ctx context.Context,
+		volumeID, volumeName string,
+		opts types.Store) (*types.Volume, error)
+
+	// VolumeCopyAfter provides an opportunity to inspect/mutate the result.
+	VolumeCopyAfter(
+		ctx context.Context,
+		result *types.Volume)
+
+	// VolumeSnapshotBefore may return an error, preventing the operation.
+	VolumeSnapshotBefore(
+		ctx context.Context,
+		volumeID, snapshotName string,
+		opts types.Store) (*types.Snapshot, error)
+
+	// VolumeSnapshotAfter provides an opportunity to inspect/mutate the result.
+	VolumeSnapshotAfter(
+		ctx context.Context,
+		result *types.Volume)
+
+	// VolumeRemoveBefore may return an error, preventing the operation.
+	VolumeRemoveBefore(
+		ctx context.Context,
+		volumeID string,
+		opts types.Store) error
+
+	// VolumeRemoveAfter provides an opportunity to inspect/mutate the result.
+	VolumeRemoveAfter(
+		ctx context.Context,
+		result *types.Volume)
+
+	// VolumeAttachBefore may return an error, preventing the operation.
+	VolumeAttachBefore(
+		ctx context.Context,
+		volumeID string,
+		opts *VolumeAttachByIDOpts) (*types.Volume, error)
+
+	// VolumeAttachAfter provides an opportunity to inspect/mutate the result.
+	VolumeAttachAfter(
+		ctx context.Context,
+		result *types.Volume)
+
+	// VolumeDetachBefore may return an error, preventing the operation.
+	VolumeDetachBefore(
+		ctx context.Context,
+		volumeID string,
+		opts types.Store) error
+
+	// VolumeDetachAfter provides an opportunity to inspect/mutate the result.
+	VolumeDetachAfter(
+		ctx context.Context,
+		result *types.Volume)
+
+	/***************************************************************************
+	**                             Snapshots                                  **
+	***************************************************************************/
+
+	// SnapshotsBefore may return an error, preventing the operation.
+	SnapshotsBefore(
+		ctx context.Context,
+		opts types.Store) ([]*types.Snapshot, error)
+
+	// SnapshotsAfter provides an opportunity to inspect/mutate the result.
+	SnapshotsAfter(
+		ctx context.Context,
+		result *types.Volume)
+
+	// SnapshotInspectBefore may return an error, preventing the operation.
+	SnapshotInspectBefore(
+		ctx context.Context,
+		snapshotID string,
+		opts types.Store) (*types.Snapshot, error)
+
+	// SnapshotInspectAfter provides an opportunity to inspect/mutate the
+	// result.
+	SnapshotInspectAfter(
+		ctx context.Context,
+		result *types.Volume)
+
+	// SnapshotCopyBefore may return an error, preventing the operation.
+	SnapshotCopyBefore(
+		ctx context.Context,
+		snapshotID, snapshotName, destinationID string,
+		opts types.Store) (*types.Snapshot, error)
+
+	// SnapshotCopyAfter provides an opportunity to inspect/mutate the result.
+	SnapshotCopyAfter(
+		ctx context.Context,
+		result *types.Volume)
+
+	// SnapshotRemoveBefore may return an error, preventing the operation.
+	SnapshotRemoveBefore(
+		ctx context.Context,
+		snapshotID string,
+		opts types.Store) error
+
+	// SnapshotRemoveAfter provides an opportunity to inspect/mutate the result.
+	SnapshotRemoveAfter(
+		ctx context.Context,
+		result *types.Volume)
+}
+
 /*
-StorageDriver is a libStorage driver used by the routes to implement the backend
-functionality.
+RemoteStorageDriver is a libStorage driver used by the routes to implement the
+backend functionality.
 
 Functions that inspect a resource or send an operation to a resource should
 always return ErrResourceNotFound if the acted upon resource cannot be found.
 */
-type StorageDriver interface {
-	StorageExecutor
+type RemoteStorageDriver interface {
+	Driver
 
 	// NextDeviceInfo returns the information about the driver's next available
 	// device workflow.

--- a/api/types/services/services.go
+++ b/api/types/services/services.go
@@ -18,6 +18,15 @@ type Service interface {
 	Init(config gofig.Config) error
 }
 
+// Services is a service's container.
+type Services interface {
+	// Storage gets the storage service.
+	Storage() StorageService
+
+	// Tasks gets the task service.
+	Tasks() TaskTrackingService
+}
+
 // TaskRunFunc is a function responsible for a task's execution.
 type TaskRunFunc func(ctx context.Context) (interface{}, error)
 
@@ -33,7 +42,7 @@ type StorageService interface {
 	Service
 
 	// Driver returns the service's StorageDriver.
-	Driver() drivers.StorageDriver
+	Driver() drivers.RemoteStorageDriver
 
 	// TaskExecute enqueues a task for execution.
 	TaskExecute(

--- a/api/types/types_errors.go
+++ b/api/types/types_errors.go
@@ -6,9 +6,14 @@ import (
 
 // JSONError is the base type for errors returned from the REST API.
 type JSONError struct {
-	Message string `json:"message"`
-	Status  int    `json:"status"`
-	Error   error  `json:"error,omitempty"`
+	Message    string      `json:"message"`
+	Status     int         `json:"status"`
+	InnerError interface{} `json:"error,omitempty"`
+}
+
+// Error returns the error message.
+func (je *JSONError) Error() string {
+	return je.Message
 }
 
 // ErrNotImplemented is the error that Driver implementations should return if

--- a/api/utils/schema/schema_generated.go
+++ b/api/utils/schema/schema_generated.go
@@ -290,7 +290,7 @@ const (
         "volumeMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/volume" }
+                "^.+$": { "$ref": "#/definitions/volume" }
             },
             "additionalProperties": false
         },
@@ -299,7 +299,7 @@ const (
         "snapshotMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/snapshot" }
+                "^.+$": { "$ref": "#/definitions/snapshot" }
             },
             "additionalProperties": false
         },
@@ -308,7 +308,7 @@ const (
         "taskMap": {
             "type": "object",
             "patternProperties": {
-                "^[0-9]+$": { "$ref": "#/definitions/task" }
+                "^.+$": { "$ref": "#/definitions/task" }
             },
             "additionalProperties": false
         },
@@ -317,7 +317,7 @@ const (
         "serviceVolumeMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/volumeMap" }
+                "^.+$": { "$ref": "#/definitions/volumeMap" }
             },
             "additionalProperties": false
         },
@@ -326,7 +326,7 @@ const (
         "serviceSnapshotMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/snapshotMap" }
+                "^.+$": { "$ref": "#/definitions/snapshotMap" }
             },
             "additionalProperties": false
         },
@@ -335,7 +335,7 @@ const (
         "serviceTaskMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/taskMap" }
+                "^.+$": { "$ref": "#/definitions/taskMap" }
             },
             "additionalProperties": false
         },
@@ -344,7 +344,7 @@ const (
         "serviceInfoMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/serviceInfo" }
+                "^.+$": { "$ref": "#/definitions/serviceInfo" }
             },
             "additionalProperties": false
         },
@@ -353,7 +353,7 @@ const (
         "executorInfoMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/executorInfo" }
+                "^.+$": { "$ref": "#/definitions/executorInfo" }
             },
             "additionalProperties": false
         },
@@ -362,7 +362,7 @@ const (
         "driverInfoMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/driverInfo" }
+                "^.+$": { "$ref": "#/definitions/driverInfo" }
             },
             "additionalProperties": false
         },
@@ -372,7 +372,7 @@ const (
             "type": "object",
             "description": "Opts are additional properties that can be defined for POST requests.",
             "patternProperties": {
-                ".+": {
+                "^.+$": {
                     "anyOf": [
                         { "type": "array" },
                         { "type": "boolean" },

--- a/drivers/storage/mock/mock_driver.go
+++ b/drivers/storage/mock/mock_driver.go
@@ -29,10 +29,10 @@ type driver struct {
 }
 
 func init() {
-	registry.RegisterStorageDriver(Name, newDriver)
+	registry.RegisterRemoteStorageDriver(Name, newDriver)
 }
 
-func newDriver() drivers.StorageDriver {
+func newDriver() drivers.RemoteStorageDriver {
 
 	d := &driver{Executor: *executor.NewExecutor()}
 
@@ -147,11 +147,13 @@ func (d *driver) VolumeCreate(
 		volume.IOPS = *opts.IOPS
 	}
 
-	if opts.Opts.IsSet("owner") {
-		volume.Fields["owner"] = opts.Opts.GetString("owner")
-	}
-	if opts.Opts.IsSet("priority") {
-		volume.Fields["priority"] = opts.Opts.GetString("priority")
+	if customFields := opts.Opts.GetStore("opts"); customFields != nil {
+		if customFields.IsSet("owner") {
+			volume.Fields["owner"] = customFields.GetString("owner")
+		}
+		if customFields.IsSet("priority") {
+			volume.Fields["priority"] = customFields.GetString("priority")
+		}
 	}
 
 	d.volumes = append(d.volumes, volume)

--- a/drivers/storage/mock/tests/mock_test.go
+++ b/drivers/storage/mock/tests/mock_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/emccode/libstorage/api/server/executors"
 	apitests "github.com/emccode/libstorage/api/tests"
+	"github.com/emccode/libstorage/api/types"
 	apihttp "github.com/emccode/libstorage/api/types/http"
 	"github.com/emccode/libstorage/client"
 
@@ -135,13 +136,24 @@ func TestVolumeCreate(t *testing.T) {
 }
 
 func TestVolumeRemove(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+
+	tf1 := func(config gofig.Config, client client.Client, t *testing.T) {
 		err := client.VolumeRemove("mock", "vol-000")
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
 	}
-	apitests.Run(t, mock.Name, configYAML, tf)
+
+	apitests.Run(t, mock.Name, configYAML, tf1, tf1)
+
+	tf2 := func(config gofig.Config, client client.Client, t *testing.T) {
+		err := client.VolumeRemove("mock", "vol-000")
+		assert.Error(t, err)
+		assert.IsType(t, &types.JSONError{}, err)
+		je := err.(*types.JSONError)
+		assert.Equal(t, "resource not found", je.Error())
+		assert.Equal(t, 404, je.Status)
+	}
+
+	apitests.RunGroup(t, mock.Name, configYAML, tf1, tf2)
 }
 
 func TestExecutors(t *testing.T) {

--- a/drivers/storage/vfs/executor/vfs_executor.go
+++ b/drivers/storage/vfs/executor/vfs_executor.go
@@ -1,16 +1,22 @@
 package executor
 
 import (
+	"bufio"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"regexp"
+	"sync"
 
 	"github.com/akutz/gofig"
+	"github.com/akutz/goof"
 	"github.com/akutz/gotil"
 
 	"github.com/emccode/libstorage/api/registry"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/types/context"
 	"github.com/emccode/libstorage/api/types/drivers"
+	"github.com/emccode/libstorage/api/utils/paths"
 )
 
 const (
@@ -18,18 +24,21 @@ const (
 	Name = "vfs"
 )
 
+var (
+	devFileLocks    = map[string]*sync.RWMutex{}
+	devFileLocksRWL = &sync.RWMutex{}
+)
+
 // Executor is the storage executor for the VFS storage driver.
 type Executor struct {
-
-	// Config is the executor's configuration instance.
-	Config gofig.Config
-
+	config      gofig.Config
+	rootDir     string
 	devFilePath string
+	volDirPath  string
 }
 
 func init() {
 	gofig.Register(configRegistration())
-
 	registry.RegisterStorageExecutor(Name, newExecutor)
 }
 
@@ -38,12 +47,29 @@ func newExecutor() drivers.StorageExecutor {
 }
 
 func (d *Executor) Init(config gofig.Config) error {
-	d.Config = config
+	d.config = config
 
-	d.devFilePath = fmt.Sprintf("%s/dev", d.RootDir())
-	if !gotil.FileExists(d.devFilePath) {
-
+	d.rootDir = d.config.GetString("vfs.root")
+	if err := os.MkdirAll(d.rootDir, 0755); err != nil {
+		return err
 	}
+
+	d.volDirPath = fmt.Sprintf("%s/vol", d.rootDir)
+	if err := os.MkdirAll(d.volDirPath, 0755); err != nil {
+		return err
+	}
+
+	d.devFilePath = fmt.Sprintf("%s/dev", d.rootDir)
+	if !gotil.FileExists(d.devFilePath) {
+		err := ioutil.WriteFile(d.devFilePath, initialDeviceFile, 0644)
+		if err != nil {
+			return err
+		}
+	}
+
+	devFileLocksRWL.Lock()
+	defer devFileLocksRWL.Unlock()
+	devFileLocks[d.devFilePath] = &sync.RWMutex{}
 
 	return nil
 }
@@ -56,7 +82,131 @@ func (d *Executor) Name() string {
 func (d *Executor) InstanceID(
 	ctx context.Context,
 	opts types.Store) (*types.InstanceID, error) {
+	return GetInstanceID()
+}
 
+var (
+	avaiDevRX = regexp.MustCompile(`^(/dev/xvd[a-z])$`)
+)
+
+// NextDevice returns the next available device.
+func (d *Executor) NextDevice(
+	ctx context.Context,
+	opts types.Store) (string, error) {
+
+	var devFileRWL *sync.RWMutex
+	func() {
+		devFileLocksRWL.RLock()
+		defer devFileLocksRWL.RUnlock()
+		devFileRWL = devFileLocks[d.devFilePath]
+	}()
+	devFileRWL.Lock()
+	defer devFileRWL.Unlock()
+
+	if !gotil.FileExists(d.devFilePath) {
+		return "", goof.New("device file missing")
+	}
+
+	f, err := os.Open(d.devFilePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	scn := bufio.NewScanner(f)
+	for {
+		if !scn.Scan() {
+			break
+		}
+
+		m := avaiDevRX.FindSubmatch(scn.Bytes())
+		if len(m) == 0 {
+			continue
+		}
+
+		return string(m[1]), nil
+	}
+
+	return "", goof.New("no available devices")
+}
+
+var (
+	devRX = regexp.MustCompile(`^(/dev/xvd[a-z])(?:=(.+))?$`)
+)
+
+// LocalDevices returns a map of the system's local devices.
+func (d *Executor) LocalDevices(
+	ctx context.Context,
+	opts types.Store) (map[string]string, error) {
+
+	var devFileRWL *sync.RWMutex
+	func() {
+		devFileLocksRWL.RLock()
+		defer devFileLocksRWL.RUnlock()
+		devFileRWL = devFileLocks[d.devFilePath]
+	}()
+	devFileRWL.Lock()
+	defer devFileRWL.Unlock()
+
+	if !gotil.FileExists(d.devFilePath) {
+		return nil, goof.New("device file missing")
+	}
+
+	f, err := os.Open(d.devFilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	localDevs := map[string]string{}
+
+	scn := bufio.NewScanner(f)
+	for {
+		if !scn.Scan() {
+			break
+		}
+
+		m := devRX.FindSubmatch(scn.Bytes())
+		if len(m) == 0 {
+			continue
+		}
+
+		dev := m[1]
+		var mountPoint []byte
+		if len(m) > 2 {
+			mountPoint = m[2]
+		}
+
+		localDevs[string(dev)] = string(mountPoint)
+	}
+
+	return localDevs, nil
+}
+
+// RootDir returns the path to the VFS root directory.
+func (d *Executor) RootDir() string {
+	return d.rootDir
+}
+
+// DeviceFilePath returns the path to the VFS devices file.
+func (d *Executor) DeviceFilePath() string {
+	return d.devFilePath
+}
+
+// VolumesDirPath returns the path to the VFS volumes directory.
+func (d *Executor) VolumesDirPath() string {
+	return d.volDirPath
+}
+
+func configRegistration() *gofig.Registration {
+	defaultRootDir := fmt.Sprintf("%s/vfs", paths.UsrDirPath)
+	r := gofig.NewRegistration("VFS")
+	r.Key(gofig.String, "", defaultRootDir, "", "vfs.root")
+	return r
+}
+
+// GetInstanceID returns the instance ID.
+func GetInstanceID() (*types.InstanceID, error) {
 	hostName, err := getHostName()
 	if err != nil {
 		return nil, err
@@ -64,30 +214,7 @@ func (d *Executor) InstanceID(
 	return &types.InstanceID{ID: hostName}, nil
 }
 
-// NextDevice returns the next available device.
-func (d *Executor) NextDevice(
-	ctx context.Context,
-	opts types.Store) (string, error) {
-	return "", nil
-}
-
-// LocalDevices returns a map of the system's local devices.
-func (d *Executor) LocalDevices(
-	ctx context.Context,
-	opts types.Store) (map[string]string, error) {
-
-	return nil, nil
-}
-
-// RootDir returns the path to the VFS root directory.
-func (d *Executor) RootDir() string {
-	return d.Config.GetString("vfs.root")
-}
-
-func configRegistration() *gofig.Registration {
-
-	defaultRootDir := fmt.Sprintf("%s/libstorage-vfs", os.TempDir())
-	r := gofig.NewRegistration("VFS")
-	r.Key(gofig.String, "", "", defaultRootDir, "vfs.root")
-	return r
-}
+var initialDeviceFile = []byte(`/dev/xvda
+/dev/xvdb
+/dev/xvdc
+/dev/xvdd`)

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -4,12 +4,14 @@ import (
 	"testing"
 
 	"github.com/akutz/gofig"
+	"github.com/stretchr/testify/assert"
 
 	apitests "github.com/emccode/libstorage/api/tests"
 	"github.com/emccode/libstorage/client"
 
 	// load the driver
 	"github.com/emccode/libstorage/drivers/storage/vfs"
+	vfsx "github.com/emccode/libstorage/drivers/storage/vfs/executor"
 )
 
 func TestVolumes(t *testing.T) {
@@ -23,4 +25,38 @@ func TestVolumes(t *testing.T) {
 	}
 
 	apitests.Run(t, vfs.Name, nil, tf)
+}
+
+func TestInstanceID(t *testing.T) {
+	iid, err := vfsx.GetInstanceID()
+	assert.NoError(t, err)
+	apitests.RunGroup(
+		t, vfs.Name, nil,
+		(&apitests.InstanceIDTest{
+			Driver:   vfs.Name,
+			Expected: iid,
+		}).Test)
+}
+
+func TestNextDevice(t *testing.T) {
+	apitests.RunGroup(
+		t, vfs.Name, nil,
+		(&apitests.NextDeviceTest{
+			Driver:   vfs.Name,
+			Expected: "/dev/xvda",
+		}).Test)
+}
+
+func TestLocalDevices(t *testing.T) {
+	apitests.RunGroup(
+		t, vfs.Name, nil,
+		(&apitests.LocalDevicesTest{
+			Driver: vfs.Name,
+			Expected: map[string]string{
+				"/dev/xvda": "",
+				"/dev/xvdb": "",
+				"/dev/xvdc": "",
+				"/dev/xvdd": "",
+			},
+		}).Test)
 }

--- a/drivers/storage/vfs/vfs_driver.go
+++ b/drivers/storage/vfs/vfs_driver.go
@@ -1,10 +1,19 @@
 package vfs
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/akutz/gofig"
+	"github.com/akutz/gotil"
 	"github.com/emccode/libstorage/api/registry"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/types/context"
 	"github.com/emccode/libstorage/api/types/drivers"
+	"github.com/emccode/libstorage/api/utils"
 	"github.com/emccode/libstorage/drivers/storage/vfs/executor"
 )
 
@@ -15,14 +24,35 @@ const (
 
 type driver struct {
 	executor.Executor
+	config gofig.Config
+
+	volJSONGlobPatt string
+	volCount        int64
 }
 
 func init() {
-	registry.RegisterStorageDriver(executor.Name, newDriver)
+	registry.RegisterRemoteStorageDriver(executor.Name, newDriver)
 }
 
-func newDriver() drivers.StorageDriver {
-	return &driver{executor.Executor{}}
+func newDriver() drivers.RemoteStorageDriver {
+	return &driver{Executor: executor.Executor{}}
+}
+
+func (d *driver) Init(config gofig.Config) error {
+	if err := d.Executor.Init(config); err != nil {
+		return err
+	}
+
+	d.config = config
+	d.volJSONGlobPatt = fmt.Sprintf("%s/*.json", d.Executor.VolumesDirPath())
+
+	volJSONPaths, err := d.getVolJSONs()
+	if err != nil {
+		return nil
+	}
+	d.volCount = int64(len(volJSONPaths)) - 1
+
+	return nil
 }
 
 func (d *driver) Type() types.StorageType {
@@ -30,7 +60,9 @@ func (d *driver) Type() types.StorageType {
 }
 
 func (d *driver) NextDeviceInfo() *types.NextDeviceInfo {
-	return nil
+	return &types.NextDeviceInfo{
+		Ignore: true,
+	}
 }
 
 func (d *driver) InstanceInspect(
@@ -42,21 +74,67 @@ func (d *driver) InstanceInspect(
 func (d *driver) Volumes(
 	ctx context.Context,
 	opts *drivers.VolumesOpts) ([]*types.Volume, error) {
-	return nil, nil
+
+	volJSONPaths, err := d.getVolJSONs()
+	if err != nil {
+		return nil, err
+	}
+
+	volumes := []*types.Volume{}
+
+	for _, volJSONPath := range volJSONPaths {
+		v, err := readVolume(volJSONPath)
+		if err != nil {
+			return nil, err
+		}
+		volumes = append(volumes, v)
+	}
+
+	return volumes, nil
 }
 
 func (d *driver) VolumeInspect(
 	ctx context.Context,
 	volumeID string,
 	opts *drivers.VolumeInspectOpts) (*types.Volume, error) {
-	return nil, nil
+
+	return d.getVolumeByID(volumeID)
 }
 
 func (d *driver) VolumeCreate(
 	ctx context.Context,
 	name string,
 	opts *drivers.VolumeCreateOpts) (*types.Volume, error) {
-	return nil, nil
+
+	v := &types.Volume{
+		ID:     d.newVolumeID(),
+		Name:   name,
+		Fields: map[string]string{},
+	}
+
+	if opts.AvailabilityZone != nil {
+		v.AvailabilityZone = *opts.AvailabilityZone
+	}
+	if opts.IOPS != nil {
+		v.IOPS = *opts.IOPS
+	}
+	if opts.Size != nil {
+		v.Size = *opts.Size
+	}
+	if opts.Type != nil {
+		v.Type = *opts.Type
+	}
+	if customFields := opts.Opts.GetStore("opts"); customFields != nil {
+		for _, k := range customFields.Keys() {
+			v.Fields[k] = customFields.GetString(k)
+		}
+	}
+
+	if err := d.writeVolume(v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
 }
 
 func (d *driver) VolumeCreateFromSnapshot(
@@ -70,7 +148,33 @@ func (d *driver) VolumeCopy(
 	ctx context.Context,
 	volumeID, volumeName string,
 	opts types.Store) (*types.Volume, error) {
-	return nil, nil
+
+	ogVol, err := d.getVolumeByID(volumeID)
+	if err != nil {
+		return nil, err
+	}
+
+	newVol := &types.Volume{
+		ID:               d.newVolumeID(),
+		Name:             volumeName,
+		AvailabilityZone: ogVol.AvailabilityZone,
+		IOPS:             ogVol.IOPS,
+		Size:             ogVol.Size,
+		Type:             ogVol.Type,
+		Fields:           map[string]string{},
+	}
+
+	if ogVol.Fields != nil {
+		for k, v := range ogVol.Fields {
+			newVol.Fields[k] = v
+		}
+	}
+
+	if err := d.writeVolume(newVol); err != nil {
+		return nil, err
+	}
+
+	return newVol, nil
 }
 
 func (d *driver) VolumeSnapshot(
@@ -126,4 +230,58 @@ func (d *driver) SnapshotRemove(
 	snapshotID string,
 	opts types.Store) error {
 	return nil
+}
+
+func (d *driver) getVolumeByID(volumeID string) (*types.Volume, error) {
+	volJSONPath :=
+		fmt.Sprintf("%s/%s.json", d.Executor.VolumesDirPath(), volumeID)
+
+	if !gotil.FileExists(volJSONPath) {
+		return nil, utils.NewNotFoundError(volumeID)
+	}
+
+	return readVolume(volJSONPath)
+}
+
+func readVolume(path string) (*types.Volume, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	v := &types.Volume{}
+	if err := json.NewDecoder(f).Decode(v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+func (d *driver) writeVolume(v *types.Volume) error {
+	volJSONPath :=
+		fmt.Sprintf("%s/vol-%s.json", d.Executor.VolumesDirPath(), v.ID)
+
+	f, err := os.Create(volJSONPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+
+	if err := enc.Encode(v); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *driver) getVolJSONs() ([]string, error) {
+	volPatt := fmt.Sprintf("%s/*.json", d.Executor.VolumesDirPath())
+	return filepath.Glob(volPatt)
+}
+
+func (d *driver) newVolumeID() string {
+	return fmt.Sprintf("vfs-%3d", atomic.AddInt64(&d.volCount, 1))
 }

--- a/libstorage.go
+++ b/libstorage.go
@@ -49,10 +49,11 @@ func init() {
 	registerGofigDefaults()
 }
 
-// RegisterStorageDriver registers a new StorageDriver with the libStorage
-// service.
-func RegisterStorageDriver(name string, ctor drivers.NewStorageDriver) {
-	registry.RegisterStorageDriver(name, ctor)
+// RegisterRemoteStorageDriver registers a new RemoteStorageDriver with the
+// libStorage service.
+func RegisterRemoteStorageDriver(
+	name string, ctor drivers.NewRemoteStorageDriver) {
+	registry.RegisterRemoteStorageDriver(name, ctor)
 }
 
 // RegisterOSDriver registers a new StorageDriver with the libStorage

--- a/libstorage.json
+++ b/libstorage.json
@@ -286,7 +286,7 @@
         "volumeMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/volume" }
+                "^.+$": { "$ref": "#/definitions/volume" }
             },
             "additionalProperties": false
         },
@@ -295,7 +295,7 @@
         "snapshotMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/snapshot" }
+                "^.+$": { "$ref": "#/definitions/snapshot" }
             },
             "additionalProperties": false
         },
@@ -304,7 +304,7 @@
         "taskMap": {
             "type": "object",
             "patternProperties": {
-                "^[0-9]+$": { "$ref": "#/definitions/task" }
+                "^.+$": { "$ref": "#/definitions/task" }
             },
             "additionalProperties": false
         },
@@ -313,7 +313,7 @@
         "serviceVolumeMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/volumeMap" }
+                "^.+$": { "$ref": "#/definitions/volumeMap" }
             },
             "additionalProperties": false
         },
@@ -322,7 +322,7 @@
         "serviceSnapshotMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/snapshotMap" }
+                "^.+$": { "$ref": "#/definitions/snapshotMap" }
             },
             "additionalProperties": false
         },
@@ -331,7 +331,7 @@
         "serviceTaskMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/taskMap" }
+                "^.+$": { "$ref": "#/definitions/taskMap" }
             },
             "additionalProperties": false
         },
@@ -340,7 +340,7 @@
         "serviceInfoMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/serviceInfo" }
+                "^.+$": { "$ref": "#/definitions/serviceInfo" }
             },
             "additionalProperties": false
         },
@@ -349,7 +349,7 @@
         "executorInfoMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/executorInfo" }
+                "^.+$": { "$ref": "#/definitions/executorInfo" }
             },
             "additionalProperties": false
         },
@@ -358,7 +358,7 @@
         "driverInfoMap": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-Z].+$": { "$ref": "#/definitions/driverInfo" }
+                "^.+$": { "$ref": "#/definitions/driverInfo" }
             },
             "additionalProperties": false
         },
@@ -368,7 +368,7 @@
             "type": "object",
             "description": "Opts are additional properties that can be defined for POST requests.",
             "patternProperties": {
-                ".+": {
+                "^.+$": {
                     "anyOf": [
                         { "type": "array" },
                         { "type": "boolean" },


### PR DESCRIPTION
This patch represents additional VFS driver work, and would not normally be committed yet, but it's too tied up in a fix @clintonskitson needs for a logic issue we found with singletons regarding the Services layer.

FWIW, this patch is also the first commit with the new `RemoteStorageDriver` and `ClientStorageDriver` interfaces -- the latter is for @clintonskitson -- he will be grinning ear-to-ear when he sees what it is as he'll immediately understand what it means.