### PR TITLE
Updated ServiceSnapshots to SnapshotsByService

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -36,10 +36,6 @@ type Client interface {
 	// ServiceInspect returns information about a service.
 	ServiceInspect(service string) (*types.ServiceInfo, error)
 
-	// ServiceSnapshots returns a single snapshot from a service.
-	ServiceSnapshots(
-		service string) (apihttp.SnapshotMap, error)
-
 	// Volumes returns a list of all Volumes for all Services.
 	Volumes() (apihttp.ServiceVolumeMap, error)
 
@@ -64,6 +60,10 @@ type Client interface {
 
 	// Volumes returns a list of all Snapshots for all services.
 	Snapshots() (apihttp.ServiceSnapshotMap, error)
+
+	// ServiceSnapshots returns a single snapshot from a service.
+	SnapshotsByService(
+		service string) (apihttp.SnapshotMap, error)
 
 	// VolumeInspect gets information about a single snapshot.
 	SnapshotInspect(
@@ -200,7 +200,7 @@ func (c *client) ServiceInspect(name string) (*types.ServiceInfo, error) {
 	return reply, nil
 }
 
-func (c *client) ServiceSnapshots(
+func (c *client) SnapshotsByService(
 	service string) (apihttp.SnapshotMap, error) {
 	reply := apihttp.SnapshotMap{}
 	if _, err := c.httpGet(

--- a/drivers/storage/mock/tests/mock_test.go
+++ b/drivers/storage/mock/tests/mock_test.go
@@ -83,9 +83,9 @@ func TestServiceInpspect(t *testing.T) {
 	apitests.Run(t, mock.Name, configYAML, tf)
 }
 
-func TestServiceSnapshots(t *testing.T) {
+func TestSnapshotsByService(t *testing.T) {
 	tf := func(config gofig.Config, client client.Client, t *testing.T) {
-		reply, err := client.ServiceSnapshots("mock")
+		reply, err := client.SnapshotsByService("mock")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This commit updates the method name of ServiceSnapshots to align
closer to swagger spec for method names.