### PR TITLE
Fix for Goof update

### DIFF
--- a/api/types/types_errors.go
+++ b/api/types/types_errors.go
@@ -22,22 +22,22 @@ var ErrNotImplemented = goof.New("not implemented")
 
 // ErrNotFound occurs when a Driver inspects or sends an operation to a
 // resource that cannot be found.
-type ErrNotFound struct{ *goof.Goof }
+type ErrNotFound struct{ goof.Goof }
 
 // ErrStoreKey occurs when no value exists for a specified store key.
-type ErrStoreKey struct{ *goof.Goof }
+type ErrStoreKey struct{ goof.Goof }
 
 // ErrContextKey occurs when no value exists for a specified context key.
-type ErrContextKey struct{ *goof.Goof }
+type ErrContextKey struct{ goof.Goof }
 
 // ErrContextType occurs when a value exists in the context but is not the
 // expected typed.
-type ErrContextType struct{ *goof.Goof }
+type ErrContextType struct{ goof.Goof }
 
 // ErrDriverTypeErr occurs when a Driver is constructed with an invalid type.
-type ErrDriverTypeErr struct{ *goof.Goof }
+type ErrDriverTypeErr struct{ goof.Goof }
 
 // ErrBatchProcess occurs when a batch process is interrupted by an error
 // before the process is complete. This error will contain information about
 // the objects for which the process did complete.
-type ErrBatchProcess struct{ *goof.Goof }
+type ErrBatchProcess struct{ goof.Goof }

--- a/api/utils/utils_errors.go
+++ b/api/utils/utils_errors.go
@@ -9,29 +9,35 @@ import (
 // NewNotFoundError returns a new ErrNotFound error.
 func NewNotFoundError(resourceID string) error {
 	return &types.ErrNotFound{
-		Goof: goof.WithField("resourceID", resourceID, "resource not found")}
+		Goof: goof.WithField("resourceID", resourceID, "resource not found"),
+	}
 }
 
 // NewStoreKeyErr returns a new ErrStoreKey error.
 func NewStoreKeyErr(storeKey string) error {
 	return &types.ErrStoreKey{
-		Goof: goof.WithField("storeKey", storeKey, "missing store key")}
+		Goof: goof.WithField("storeKey", storeKey, "missing store key"),
+	}
 }
 
 // NewContextKeyErr returns a new ErrContextKey error.
 func NewContextKeyErr(contextKey string) error {
 	return &types.ErrContextKey{
-		Goof: goof.WithField("contextKey", contextKey, "missing context key")}
+		Goof: goof.WithField("contextKey", contextKey, "missing context key"),
+	}
 }
 
 // NewContextTypeErr returns a new ErrContextType error.
 func NewContextTypeErr(
 	contextKey, expectedType, actualType string) error {
-	return &types.ErrContextType{Goof: goof.WithFields(goof.Fields{
-		"contextKey":   contextKey,
-		"expectedType": expectedType,
-		"actualType":   actualType,
-	}, "invalid context type")}
+
+	return &types.ErrContextType{
+		Goof: goof.WithFields(
+			goof.Fields{
+				"contextKey":   contextKey,
+				"expectedType": expectedType,
+				"actualType":   actualType,
+			}, "invalid context type")}
 }
 
 // NewDriverTypeErr returns a new ErrDriverTypeErr error.


### PR DESCRIPTION
This patch fixes the change to the Goof library so that the Goof type is no longer a struct, but an interface.