### PR TITLE
LSXBin Chmod Text File Busy Fix

### DIFF
--- a/client/client_init.go
+++ b/client/client_init.go
@@ -228,14 +228,21 @@ func (c *lsc) getExecutorChecksum() (string, error) {
 }
 
 func (c *lsc) downloadExecutor() error {
-	f, err := os.Create(c.lsxBinPath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
 
-	rdr, err := c.Client.ExecutorGet(c.ctx, executors.LSX)
-	if _, err := io.Copy(f, rdr); err != nil {
+	if err := func() error {
+		f, err := os.Create(c.lsxBinPath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		rdr, err := c.Client.ExecutorGet(c.ctx, executors.LSX)
+		if _, err := io.Copy(f, rdr); err != nil {
+			return err
+		}
+
+		return nil
+	}(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The libStorage executor was not properly closed prior to attempting to chmod it, resulting in a file busy error. This patch should alleviate the issue.