### PR TITLE
WIP - Add ScaleIO Driver to Libstorage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: build
 
 # a space-delimited, ordered list of drivers for which to build the libstorage
 # server, client(s), and executor(s)
-DRIVERS ?= mock vfs
+DRIVERS ?= mock vfs scaleio
 
 ################################################################################
 ##                                 CONSTANTS                                  ##

--- a/drivers/storage/scaleio/executor/scaleio_executor.go
+++ b/drivers/storage/scaleio/executor/scaleio_executor.go
@@ -1,0 +1,133 @@
+package executor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/akutz/gofig"
+	"github.com/emccode/libstorage/api/registry"
+	"github.com/emccode/libstorage/api/types"
+	"github.com/emccode/libstorage/api/types/context"
+	"github.com/emccode/libstorage/api/types/drivers"
+)
+
+const Name = "scaleio"
+
+// Executor is the storage executor for the ScaleIO storage driver.
+type StorageExecutor struct {
+	Config     gofig.Config
+	name       string
+	instanceID *types.InstanceID
+	InitDriver func() error
+}
+
+func init() {
+	gofig.Register(configRegistration())
+	registry.RegisterStorageExecutor(Name, newExecutor)
+}
+
+func (e *StorageExecutor) Init(config gofig.Config) error {
+	e.Config = config
+	if e.InitDriver != nil {
+		if err := e.InitDriver(); err != nil {
+			return err
+		}
+	}
+	instanceID, err := getSdcLocalGUID()
+	if err != nil {
+		return err
+	}
+	e.instanceID = &types.InstanceID{ID: instanceID}
+	return nil
+}
+
+func newExecutor() drivers.StorageExecutor {
+	return NewExecutor()
+}
+
+func NewExecutor() *StorageExecutor {
+	return &StorageExecutor{
+		name:       Name,
+	}
+}
+
+func (e *StorageExecutor) Name() string {
+	return e.name
+}
+
+// InstanceID returns the local system's InstanceID.
+func (e *StorageExecutor) InstanceID(
+	ctx context.Context,
+	opts types.Store) (*types.InstanceID, error) {
+	return e.instanceID, nil
+}
+
+// NextDevice returns the next available device.
+func (e *StorageExecutor) NextDevice(
+	ctx context.Context,
+	opts types.Store) (string, error) {
+	return "", nil
+}
+
+// LocalDevices returns a map of the system's local devices.
+func (e *StorageExecutor) LocalDevices(
+	ctx context.Context,
+	opts types.Store) (map[string]string, error) {
+
+	var volumeMap = make(map[string]string)
+
+	diskIDPath := "/dev/disk/by-id"
+	files, _ := ioutil.ReadDir(diskIDPath)
+	r, _ := regexp.Compile(`^emc-vol-\w*-\w*$`)
+	for _, f := range files {
+		matched := r.MatchString(f.Name())
+		if matched {
+			mdmVolumeID := strings.Replace(f.Name(), "emc-vol-", "", 1)
+			devPath, _ := filepath.EvalSymlinks(fmt.Sprintf("%s/%s", diskIDPath, f.Name()))
+			volumeID := strings.Split(mdmVolumeID, "-")[1]
+			volumeMap[volumeID] = devPath
+		}
+	}
+	return volumeMap, nil
+}
+
+func configRegistration() *gofig.Registration {
+	r := gofig.NewRegistration("ScaleIO")
+	r.Key(gofig.String, "", "", "", "scaleio.endpoint")
+	r.Key(gofig.Bool, "", false, "", "scaleio.insecure")
+	r.Key(gofig.Bool, "", false, "", "scaleio.useCerts")
+	r.Key(gofig.String, "", "", "", "scaleio.userID")
+	r.Key(gofig.String, "", "", "", "scaleio.userName")
+	r.Key(gofig.String, "", "", "", "scaleio.password")
+	r.Key(gofig.String, "", "", "", "scaleio.systemID")
+	r.Key(gofig.String, "", "", "", "scaleio.systemName")
+	r.Key(gofig.String, "", "", "", "scaleio.protectionDomainID")
+	r.Key(gofig.String, "", "", "", "scaleio.protectionDomainName")
+	r.Key(gofig.String, "", "", "", "scaleio.storagePoolID")
+	r.Key(gofig.String, "", "", "", "scaleio.storagePoolName")
+	r.Key(gofig.String, "", "", "", "scaleio.thinOrThick")
+	r.Key(gofig.String, "", "", "", "scaleio.version")
+	return r
+}
+
+func getSdcLocalGUID() (sdcGUID string, err error) {
+
+	// get sdc kernel guid
+	// /bin/emc/scaleio/drv_cfg --query_guid
+	// sdcKernelGuid := "271bad82-08ee-44f2-a2b1-7e2787c27be1"
+
+	out, err := exec.Command("/opt/emc/scaleio/sdc/bin/drv_cfg", "--query_guid").Output()
+	if err != nil {
+		return "", fmt.Errorf("Error querying volumes: ", err)
+	}
+
+	sdcGUID = strings.Replace(string(out), "\n", "", -1)
+
+	return sdcGUID, nil
+}
+
+

--- a/drivers/storage/scaleio/executor/scaleio_executor.go
+++ b/drivers/storage/scaleio/executor/scaleio_executor.go
@@ -11,8 +11,6 @@ import (
 	"github.com/akutz/gofig"
 	"github.com/emccode/libstorage/api/registry"
 	"github.com/emccode/libstorage/api/types"
-	"github.com/emccode/libstorage/api/types/context"
-	"github.com/emccode/libstorage/api/types/drivers"
 )
 
 const Name = "scaleio"
@@ -30,7 +28,7 @@ func init() {
 	registry.RegisterStorageExecutor(Name, newExecutor)
 }
 
-func (e *StorageExecutor) Init(config gofig.Config) error {
+func (e *StorageExecutor) Init(ctx types.Context, config gofig.Config) error {
 	e.Config = config
 	if e.InitDriver != nil {
 		if err := e.InitDriver(); err != nil {
@@ -45,7 +43,7 @@ func (e *StorageExecutor) Init(config gofig.Config) error {
 	return nil
 }
 
-func newExecutor() drivers.StorageExecutor {
+func newExecutor() types.StorageExecutor {
 	return NewExecutor()
 }
 
@@ -61,21 +59,21 @@ func (e *StorageExecutor) Name() string {
 
 // InstanceID returns the local system's InstanceID.
 func (e *StorageExecutor) InstanceID(
-	ctx context.Context,
+	ctx types.Context,
 	opts types.Store) (*types.InstanceID, error) {
 	return e.instanceID, nil
 }
 
 // NextDevice returns the next available device.
 func (e *StorageExecutor) NextDevice(
-	ctx context.Context,
+	ctx types.Context,
 	opts types.Store) (string, error) {
 	return "", nil
 }
 
 // LocalDevices returns a map of the system's local devices.
 func (e *StorageExecutor) LocalDevices(
-	ctx context.Context,
+	ctx types.Context,
 	opts types.Store) (map[string]string, error) {
 
 	var volumeMap = make(map[string]string)

--- a/drivers/storage/scaleio/scaleio_driver.go
+++ b/drivers/storage/scaleio/scaleio_driver.go
@@ -1,0 +1,855 @@
+package scaleio
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/akutz/goof"
+
+	"github.com/emccode/goscaleio"
+	goscaleioTypes "github.com/emccode/goscaleio/types/v1"
+
+	"github.com/emccode/libstorage/api/registry"
+	"github.com/emccode/libstorage/api/types"
+	"github.com/emccode/libstorage/api/types/context"
+	"github.com/emccode/libstorage/api/types/drivers"
+	"github.com/emccode/libstorage/drivers/storage/scaleio/executor"
+)
+
+const (
+	// Name is the name of the driver.
+	Name = executor.Name
+	cc   = 31
+)
+
+type driver struct {
+	executor.StorageExecutor
+	nextDeviceInfo   *types.NextDeviceInfo
+	volumes          []*types.Volume
+	snapshots        []*types.Snapshot
+	client           *goscaleio.Client
+	system           *goscaleio.System
+	protectionDomain *goscaleio.ProtectionDomain
+	storagePool      *goscaleio.StoragePool
+	sdc              *goscaleio.Sdc
+}
+
+func init() {
+	registry.RegisterRemoteStorageDriver(Name, newDriver)
+}
+
+func newDriver() drivers.RemoteStorageDriver {
+	d := &driver{StorageExecutor: *executor.NewExecutor()}
+	d.StorageExecutor.InitDriver = d.driverInit
+	return d
+}
+
+func (d *driver) driverInit() error {
+
+	fields := eff(map[string]interface{}{
+		"endpoint": d.endpoint(),
+		"version":  d.version(),
+		"insecure": d.insecure(),
+		"useCerts": d.useCerts(),
+	})
+
+	var err error
+
+	if d.client, err = goscaleio.NewClientWithArgs(
+		d.endpoint(),
+		d.version(),
+		d.insecure(),
+		d.useCerts()); err != nil {
+		return goof.WithFieldsE(fields, "error constructing new client", err)
+	}
+	if _, err := d.client.Authenticate(
+
+		&goscaleio.ConfigConnect{
+			d.endpoint(),
+			d.version(),
+			d.userName(),
+			d.password()}); err != nil {
+		fields["userName"] = d.userName()
+		if d.password() != "" {
+			fields["password"] = "******"
+		}
+
+		return goof.WithFieldsE(fields, "error authenticating", err)
+	}
+	if d.system, err = d.client.FindSystem(
+		d.systemID(),
+		d.systemName(), ""); err != nil {
+		fields["systemId"] = d.systemID()
+		fields["systemName"] = d.systemName()
+		return goof.WithFieldsE(fields, "error finding system", err)
+	}
+
+	var pd *goscaleioTypes.ProtectionDomain
+	if pd, err = d.system.FindProtectionDomain(
+		d.protectionDomainID(),
+		d.protectionDomainName(), ""); err != nil {
+		fields["domainId"] = d.protectionDomainID()
+		fields["domainName"] = d.protectionDomainName()
+		return goof.WithFieldsE(fields,
+			"error finding protection domain", err)
+	}
+	d.protectionDomain = goscaleio.NewProtectionDomain(d.client)
+	d.protectionDomain.ProtectionDomain = pd
+
+	var sp *goscaleioTypes.StoragePool
+	if sp, err = d.protectionDomain.FindStoragePool(
+		d.storagePoolID(),
+		d.storagePoolName(), ""); err != nil {
+		fields["storagePoolId"] = d.storagePoolID()
+		fields["storagePoolName"] = d.storagePoolName()
+		return goof.WithFieldsE(fields, "error finding storage pool", err)
+	}
+	d.storagePool = goscaleio.NewStoragePool(d.client)
+	d.storagePool.StoragePool = sp
+
+	var sdcGUID string
+	if sdcGUID, err = goscaleio.GetSdcLocalGUID(); err != nil {
+		return goof.WithFieldsE(fields, "error getting sdc local guid", err)
+	}
+
+	if d.sdc, err = d.system.FindSdc(
+		"SdcGuid",
+		strings.ToUpper(sdcGUID)); err != nil {
+		fields["sdcGuid"] = sdcGUID
+		return goof.WithFieldsE(fields, "error finding sdc", err)
+	}
+
+	log.WithFields(fields).Info("storage driver initialized")
+
+	return nil
+}
+
+func (d *driver) Type() types.StorageType {
+	return types.Block
+}
+
+// NextDeviceInfo returns the information about the driver's next available
+// device workflow.
+
+func (d *driver) NextDeviceInfo() *types.NextDeviceInfo {
+	return nil
+}
+
+func (d *driver) InstanceInspect(
+	ctx context.Context,
+	opts types.Store) (*types.Instance, error) {
+	iid, _ := d.InstanceID(ctx, opts)
+	curInstance := &types.Instance{InstanceID: iid}
+	return curInstance, nil
+}
+
+func (d *driver) Volumes(ctx context.Context,
+	opts *drivers.VolumesOpts) ([]*types.Volume, error) {
+
+	sdcMappedVolumes, err := goscaleio.GetLocalVolumeMap()
+	if err != nil {
+		return []*types.Volume{}, err
+	}
+
+	mapStoragePoolName, err := d.getStoragePoolIDs()
+	if err != nil {
+		return nil, err
+	}
+
+	mapProtectionDomainName, err := d.getProtectionDomainIDs()
+	if err != nil {
+		return nil, err
+	}
+
+	getStoragePoolName := func(ID string) string {
+		if pool, ok := mapStoragePoolName[ID]; ok {
+			return pool.Name
+		}
+		return ""
+	}
+
+	getProtectionDomainName := func(poolID string) string {
+		var ok bool
+		var pool *goscaleioTypes.StoragePool
+
+		if pool, ok = mapStoragePoolName[poolID]; !ok {
+			return ""
+		}
+
+		if protectionDomain, ok := mapProtectionDomainName[pool.ProtectionDomainID]; ok {
+			return protectionDomain.Name
+		}
+		return ""
+	}
+
+	sdcDeviceMap := make(map[string]*goscaleio.SdcMappedVolume)
+	for _, sdcMappedVolume := range sdcMappedVolumes {
+		sdcDeviceMap[sdcMappedVolume.VolumeID] = sdcMappedVolume
+	}
+
+	volumes, err := d.getVolume("", "", false)
+	if err != nil {
+		return []*types.Volume{}, err
+	}
+
+	var volumesSD []*types.Volume
+	for _, volume := range volumes {
+		var attachmentsSD []*types.VolumeAttachment
+		for _, attachment := range volume.MappedSdcInfo {
+			var deviceName string
+			if attachment.SdcID == d.sdc.Sdc.ID {
+				if _, exists := sdcDeviceMap[volume.ID]; exists {
+					deviceName = sdcDeviceMap[volume.ID].SdcDevice
+				}
+			}
+			instanceID := &types.InstanceID{
+				ID: attachment.SdcID,
+			}
+			attachmentSD := &types.VolumeAttachment{
+				VolumeID:   volume.ID,
+				InstanceID: instanceID,
+				DeviceName: deviceName,
+				Status:     "",
+			}
+			attachmentsSD = append(attachmentsSD, attachmentSD)
+		}
+
+		var IOPS int64
+		if len(volume.MappedSdcInfo) > 0 {
+			IOPS = int64(volume.MappedSdcInfo[0].LimitIops)
+		}
+		volumeSD := &types.Volume{
+			Name:             volume.Name,
+			ID:               volume.ID,
+			AvailabilityZone: getProtectionDomainName(volume.StoragePoolID),
+			Status:           "",
+			Type:             getStoragePoolName(volume.StoragePoolID),
+			IOPS:             IOPS,
+			Size:             int64(volume.SizeInKb / 1024 / 1024),
+			Attachments:      attachmentsSD,
+		}
+		volumesSD = append(volumesSD, volumeSD)
+	}
+
+	return volumesSD, nil
+}
+
+func (d *driver) VolumeInspect(
+	ctx context.Context,
+	volumeID string, opts *drivers.VolumeInspectOpts) (*types.Volume, error) {
+
+	sdcMappedVolumes, err := goscaleio.GetLocalVolumeMap()
+	if err != nil {
+		return &types.Volume{}, err
+	}
+
+	mapStoragePoolName, err := d.getStoragePoolIDs()
+	if err != nil {
+		return nil, err
+	}
+
+	mapProtectionDomainName, err := d.getProtectionDomainIDs()
+	if err != nil {
+		return nil, err
+	}
+
+	getStoragePoolName := func(ID string) string {
+		if pool, ok := mapStoragePoolName[ID]; ok {
+			return pool.Name
+		}
+		return ""
+	}
+
+	getProtectionDomainName := func(poolID string) string {
+		var ok bool
+		var pool *goscaleioTypes.StoragePool
+
+		if pool, ok = mapStoragePoolName[poolID]; !ok {
+			return ""
+		}
+
+		if protectionDomain, ok := mapProtectionDomainName[pool.ProtectionDomainID]; ok {
+			return protectionDomain.Name
+		}
+		return ""
+	}
+
+	sdcDeviceMap := make(map[string]*goscaleio.SdcMappedVolume)
+	for _, sdcMappedVolume := range sdcMappedVolumes {
+		sdcDeviceMap[sdcMappedVolume.VolumeID] = sdcMappedVolume
+	}
+	fmt.Printf("Requested VolumeID: %+v", volumeID)
+	volumes, err := d.getVolume(volumeID, "", false)
+	if err != nil {
+		return &types.Volume{}, err
+	}
+	fmt.Printf("Volumes Returned: %+v", volumes)
+
+	var volumesSD []*types.Volume
+	for _, volume := range volumes {
+		var attachmentsSD []*types.VolumeAttachment
+		for _, attachment := range volume.MappedSdcInfo {
+			var deviceName string
+			if attachment.SdcID == d.sdc.Sdc.ID {
+				if _, exists := sdcDeviceMap[volume.ID]; exists {
+					deviceName = sdcDeviceMap[volume.ID].SdcDevice
+				}
+			}
+			instanceID := &types.InstanceID{
+				ID: attachment.SdcID,
+			}
+			attachmentSD := &types.VolumeAttachment{
+				VolumeID:   volume.ID,
+				InstanceID: instanceID,
+				DeviceName: deviceName,
+				Status:     "",
+			}
+			attachmentsSD = append(attachmentsSD, attachmentSD)
+		}
+
+		var IOPS int64
+		if len(volume.MappedSdcInfo) > 0 {
+			IOPS = int64(volume.MappedSdcInfo[0].LimitIops)
+		}
+		volumeSD := &types.Volume{
+			Name:             volume.Name,
+			ID:               volume.ID,
+			AvailabilityZone: getProtectionDomainName(volume.StoragePoolID),
+			Status:           "",
+			Type:             getStoragePoolName(volume.StoragePoolID),
+			IOPS:             IOPS,
+			Size:             int64(volume.SizeInKb / 1024 / 1024),
+			Attachments:      attachmentsSD,
+		}
+		volumesSD = append(volumesSD, volumeSD)
+	}
+	if len(volumesSD) == 0 {
+		return nil, nil
+	}
+	return volumesSD[0], nil
+}
+
+func (d *driver) VolumeCreate(
+	ctx context.Context,
+	name string,
+	opts *drivers.VolumeCreateOpts) (*types.Volume, error) {
+	fmt.Printf("OPTS: %+v", opts)
+	if opts == nil {
+		opts = &drivers.VolumeCreateOpts{}
+	}
+
+	if opts.Type == nil {
+		var optType string = ""
+		opts.Type = &optType
+	}
+	if opts.IOPS == nil {
+		var iops int64 = 0
+		opts.IOPS = &iops
+	}
+	if opts.Size == nil {
+		var size int64 = 1
+		opts.Size = &size
+	}
+	if opts.AvailabilityZone == nil {
+		var availabilityZone string = ""
+		opts.AvailabilityZone = &availabilityZone
+	}
+
+	// notUsed bool,volumeName, volumeID, snapshotID, volumeType string,
+	// IOPS, size int64, availabilityZone string) (*types.VolumeResp, error)
+	if name == "" {
+		return nil, goof.WithFields(eff(map[string]interface{}{
+			"moduleName": ctx}),
+			"no volume name specified")
+	}
+
+	volumes, err := d.getVolume("", name, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(volumes) > 0 {
+		return nil, goof.WithFields(eff(map[string]interface{}{
+			"moduleName": ctx,
+			"volumeName": name}),
+			"volume name already exists")
+	}
+
+	//TODO notUsed doesn't seem to be used here...is it needed?
+	resp, err := d.createVolume(ctx,
+		false, name, "",
+		*opts.Type, *opts.IOPS, *opts.Size, *opts.AvailabilityZone)
+
+	if err != nil {
+		return nil, err
+	}
+
+	volumes, err = d.getVolume(resp.ID, "", false)
+	if err != nil {
+		return nil, err
+	}
+
+	createdVolume, err := d.VolumeInspect(ctx, resp.ID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	log.WithFields(log.Fields{
+		"moduleName": ctx,
+		"provider":   "scaleIO",
+		"volume":     createdVolume,
+	}).Debug("created volume")
+	return createdVolume, nil
+
+}
+
+func (d *driver) VolumeCreateFromSnapshot(
+	ctx context.Context,
+	snapshotID, volumeName string,
+	opts *drivers.VolumeCreateOpts) (*types.Volume, error) {
+	return nil, nil
+}
+
+func (d *driver) VolumeCopy(
+	ctx context.Context,
+	volumeID, volumeName string,
+	opts types.Store) (*types.Volume, error) {
+	return nil, nil
+}
+
+func (d *driver) VolumeSnapshot(
+	ctx context.Context,
+	volumeID, snapshotName string,
+	opts types.Store) (*types.Snapshot, error) {
+	return nil, nil
+}
+
+func (d *driver) VolumeRemove(
+	ctx context.Context,
+	volumeID string,
+	opts types.Store) error {
+
+	fields := eff(map[string]interface{}{
+		"volumeId": volumeID,
+	})
+
+	if volumeID == "" {
+		return goof.WithFields(fields, "volumeId is required")
+	}
+
+	var err error
+	var volumes []*goscaleioTypes.Volume
+
+	if volumes, err = d.getVolume(volumeID, "", false); err != nil {
+		return goof.WithFieldsE(fields, "error getting volume", err)
+	}
+
+	targetVolume := goscaleio.NewVolume(d.client)
+	targetVolume.Volume = volumes[0]
+
+	if err = targetVolume.RemoveVolume("ONLY_ME"); err != nil {
+		return goof.WithFieldsE(fields, "error removing volume", err)
+	}
+
+	log.WithFields(fields).Debug("removed volume")
+	return nil
+}
+
+func (d *driver) VolumeAttach(
+	ctx context.Context,
+	volumeID string,
+	opts *drivers.VolumeAttachByIDOpts) (*types.Volume, error) {
+
+	fields := eff(map[string]interface{}{
+		"volumeId":   volumeID,
+		"instanceId": d.InstanceID,
+	})
+
+	if volumeID == "" {
+		return nil, goof.WithFields(fields, "volumeId is required")
+	}
+
+	mapVolumeSdcParam := &goscaleioTypes.MapVolumeSdcParam{
+		SdcID: d.sdc.Sdc.ID,
+		AllowMultipleMappings: "false",
+		AllSdcs:               "",
+	}
+
+	volumes, err := d.getVolume(volumeID, "", false)
+	if err != nil {
+		return nil, goof.WithFieldsE(fields, "error getting volume", err)
+	}
+
+	if len(volumes) == 0 {
+		return nil, goof.WithFields(fields, "no volumes returned")
+	}
+
+	targetVolume := goscaleio.NewVolume(d.client)
+	targetVolume.Volume = volumes[0]
+
+	err = targetVolume.MapVolumeSdc(mapVolumeSdcParam)
+	if err != nil {
+		return nil, goof.WithFieldsE(fields, "error mapping volume sdc", err)
+	}
+
+	_, err = d.waitMount(ctx, volumes[0].ID, opts.Opts)
+	if err != nil {
+		fields["volumeId"] = volumes[0].ID
+		return nil, goof.WithFieldsE(
+			fields, "error waiting on volume to mount", err)
+	}
+
+	instanceID, _ := d.InstanceID(ctx, opts.Opts)
+	volumeInspectOpts := &drivers.VolumeInspectOpts{true, opts.Opts}
+	_, err = d.GetVolumeAttach(ctx, volumeID, instanceID.ID, volumeInspectOpts)
+	if err != nil {
+		return nil, goof.WithFieldsE(
+			fields, "error getting volume attachments", err)
+	}
+
+	log.WithFields(log.Fields{
+		"provider":   Name,
+		"volumeId":   volumeID,
+		"instanceId": instanceID.ID,
+	}).Debug("attached volume to instance")
+
+	attachedVol, err := d.VolumeInspect(ctx, volumeID, volumeInspectOpts)
+	if err != nil {
+		return nil, goof.WithFieldsE(fields, "error getting volume", err)
+	}
+
+	return attachedVol, nil
+}
+
+func (d *driver) VolumeDetach(
+	ctx context.Context,
+	volumeID string,
+	opts types.Store) error {
+	fields := eff(map[string]interface{}{
+		"moduleName": ctx,
+		"volumeId":   volumeID,
+	})
+
+	if volumeID == "" {
+		return goof.WithFields(fields, "volumeId is required")
+	}
+
+	volumes, err := d.getVolume(volumeID, "", false)
+	if err != nil {
+		return goof.WithFieldsE(fields, "error getting volume", err)
+	}
+
+	if len(volumes) == 0 {
+		return goof.WithFields(fields, "no volumes returned")
+	}
+
+	targetVolume := goscaleio.NewVolume(d.client)
+	targetVolume.Volume = volumes[0]
+
+	unmapVolumeSdcParam := &goscaleioTypes.UnmapVolumeSdcParam{
+		SdcID:                "",
+		IgnoreScsiInitiators: "true",
+		AllSdcs:              "",
+	}
+
+	unmapVolumeSdcParam.SdcID = d.sdc.Sdc.ID
+
+	_ = targetVolume.UnmapVolumeSdc(unmapVolumeSdcParam)
+
+	log.WithFields(log.Fields{
+		"moduleName": ctx,
+		"provider":   Name,
+		"volumeId":   volumeID}).Debug("detached volume")
+	return nil
+}
+
+func (d *driver) Snapshots(
+	ctx context.Context,
+	opts types.Store) ([]*types.Snapshot, error) {
+	return nil, nil
+}
+
+func (d *driver) SnapshotInspect(
+	ctx context.Context,
+	snapshotID string,
+	opts types.Store) (*types.Snapshot, error) {
+	return nil, nil
+}
+
+func (d *driver) SnapshotCopy(
+	ctx context.Context,
+	snapshotID, snapshotName, destinationID string,
+	opts types.Store) (*types.Snapshot, error) {
+	return nil, nil
+}
+
+func (d *driver) SnapshotRemove(
+	ctx context.Context,
+	snapshotID string,
+	opts types.Store) error {
+	return nil
+}
+
+///////////////////////////////////////////////////////////////////////
+////// HELPER FUNCTIONS FOR SCALEIO DRIVER FROM THIS POINT ON /////////
+///////////////////////////////////////////////////////////////////////
+
+func shrink(n string) string {
+	if len(n) > cc {
+		return n[:cc]
+	}
+	return n
+}
+
+func (d *driver) getStoragePoolIDs() (map[string]*goscaleioTypes.StoragePool, error) {
+	storagePools, err := d.client.GetStoragePool("")
+	if err != nil {
+		return nil, err
+	}
+
+	mapPoolID := make(map[string]*goscaleioTypes.StoragePool)
+
+	for _, pool := range storagePools {
+		mapPoolID[pool.ID] = pool
+	}
+	return mapPoolID, nil
+}
+
+func (d *driver) getProtectionDomainIDs() (map[string]*goscaleioTypes.ProtectionDomain, error) {
+	protectionDomains, err := d.system.GetProtectionDomain("")
+	if err != nil {
+		return nil, err
+	}
+
+	mapProtectionDomainID := make(map[string]*goscaleioTypes.ProtectionDomain)
+
+	for _, protectionDomain := range protectionDomains {
+		mapProtectionDomainID[protectionDomain.ID] = protectionDomain
+	}
+	return mapProtectionDomainID, nil
+}
+
+func (d *driver) getVolume(
+	volumeID, volumeName string, getSnapshots bool) ([]*goscaleioTypes.Volume, error) {
+
+	volumeName = shrink(volumeName)
+
+	volumes, err := d.client.GetVolume("", volumeID, "", volumeName, getSnapshots)
+	if err != nil {
+		return nil, err
+	}
+	return volumes, nil
+}
+
+func (d *driver) createVolume(ctx context.Context,
+	notUsed bool,
+	volumeName, volumeID, volumeType string,
+	IOPS, size int64, availabilityZone string) (*goscaleioTypes.VolumeResp, error) {
+
+	volumeName = shrink(volumeName)
+
+	fields := eff(map[string]interface{}{
+		"moduleName":       ctx,
+		"volumeID":         volumeID,
+		"volumeName":       volumeName,
+		"volumeType":       volumeType,
+		"IOPS":             IOPS,
+		"size":             size,
+		"availabilityZone": availabilityZone,
+	})
+
+	volumeParam := &goscaleioTypes.VolumeParam{
+		Name:           volumeName,
+		VolumeSizeInKb: strconv.Itoa(int(size) * 1024 * 1024),
+		VolumeType:     d.thinOrThick(),
+	}
+
+	if volumeType == "" {
+		volumeType = d.storagePool.StoragePool.Name
+		fields["volumeType"] = volumeType
+	}
+
+	volumeResp, err := d.client.CreateVolume(volumeParam, volumeType)
+	if err != nil {
+		return nil, goof.WithFieldsE(fields, "error creating volume", err)
+	}
+
+	return volumeResp, nil
+}
+
+//TODO change provider to be dynamic...
+
+func eff(fields goof.Fields) map[string]interface{} {
+	errFields := map[string]interface{}{
+		"provider": "scaleIO",
+	}
+	if fields != nil {
+		for k, v := range fields {
+			errFields[k] = v
+		}
+	}
+	return errFields
+}
+
+func (d *driver) waitMount(ctx context.Context, volumeID string, opts types.Store) (*goscaleio.SdcMappedVolume, error) {
+
+	timeout := make(chan bool, 1)
+	go func() {
+		time.Sleep(10 * time.Second)
+		timeout <- true
+	}()
+
+	successCh := make(chan *goscaleio.SdcMappedVolume, 1)
+	errorCh := make(chan error, 1)
+	go func(volumeID string) {
+		log.WithField("provider", Name).Debug("waiting for volume mount")
+		for {
+			sdcMappedVolumes, err := goscaleio.GetLocalVolumeMap()
+			if err != nil {
+				errorCh <- goof.WithFieldE(
+					"provider", Name,
+					"problem getting local volume mappings", err)
+				return
+			}
+
+			sdcMappedVolume := &goscaleio.SdcMappedVolume{}
+			var foundVolume bool
+			for _, sdcMappedVolume = range sdcMappedVolumes {
+				if sdcMappedVolume.VolumeID ==
+					volumeID && sdcMappedVolume.SdcDevice != "" {
+					foundVolume = true
+					break
+				}
+			}
+
+			if foundVolume {
+				successCh <- sdcMappedVolume
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+
+	}(volumeID)
+
+	select {
+	case sdcMappedVolume := <-successCh:
+		log.WithFields(log.Fields{
+			"moduleName": ctx,
+			"provider":   Name,
+			"volumeId":   sdcMappedVolume.VolumeID,
+			"volume":     sdcMappedVolume.SdcDevice,
+		}).Debug("got sdcMappedVolume")
+		return sdcMappedVolume, nil
+	case err := <-errorCh:
+		return &goscaleio.SdcMappedVolume{}, err
+	case <-timeout:
+		return &goscaleio.SdcMappedVolume{}, goof.WithFields(
+			ef(), "timed out waiting for mount")
+	}
+
+}
+
+func (d *driver) GetVolumeAttach(
+	ctx context.Context, volumeID, instanceID string, opts *drivers.VolumeInspectOpts) ([]*types.VolumeAttachment, error) {
+
+	fields := eff(map[string]interface{}{
+		"volumeId":   volumeID,
+		"instanceId": instanceID,
+	})
+
+	if volumeID == "" {
+		return []*types.VolumeAttachment{},
+			goof.WithFields(fields, "volumeId is required")
+	}
+	volume, err := d.VolumeInspect(ctx, volumeID, opts)
+	if err != nil {
+		return []*types.VolumeAttachment{},
+			goof.WithFieldsE(fields, "error getting volume", err)
+	}
+
+	if instanceID != "" {
+		var attached bool
+		for _, volumeAttachment := range volume.Attachments {
+			if volumeAttachment.InstanceID.ID == instanceID {
+				return volume.Attachments, nil
+			}
+		}
+		if !attached {
+			return []*types.VolumeAttachment{}, nil
+		}
+	}
+	return volume.Attachments, nil
+}
+
+///////////////////////////////////////////////////////////////////////
+//////                  CONFIG HELPER STUFF                   /////////
+///////////////////////////////////////////////////////////////////////
+
+func (d *driver) endpoint() string {
+	return d.StorageExecutor.Config.GetString("scaleio.endpoint")
+}
+
+func (d *driver) insecure() bool {
+	return d.StorageExecutor.Config.GetBool("scaleio.insecure")
+}
+
+func (d *driver) useCerts() bool {
+	return d.StorageExecutor.Config.GetBool("scaleio.useCerts")
+}
+
+func (d *driver) userID() string {
+	return d.StorageExecutor.Config.GetString("scaleio.userID")
+}
+
+func (d *driver) userName() string {
+	return d.StorageExecutor.Config.GetString("scaleio.userName")
+}
+
+func (d *driver) password() string {
+	return d.StorageExecutor.Config.GetString("scaleio.password")
+}
+
+func (d *driver) systemID() string {
+	return d.StorageExecutor.Config.GetString("scaleio.systemID")
+}
+
+func (d *driver) systemName() string {
+	return d.StorageExecutor.Config.GetString("scaleio.systemName")
+}
+
+func (d *driver) protectionDomainID() string {
+	return d.StorageExecutor.Config.GetString("scaleio.protectionDomainID")
+}
+
+func (d *driver) protectionDomainName() string {
+	return d.StorageExecutor.Config.GetString("scaleio.protectionDomainName")
+}
+
+func (d *driver) storagePoolID() string {
+	return d.StorageExecutor.Config.GetString("scaleio.storagePoolID")
+}
+
+func (d *driver) storagePoolName() string {
+	return d.StorageExecutor.Config.GetString("scaleio.storagePoolName")
+}
+
+func (d *driver) thinOrThick() string {
+	thinOrThick := d.StorageExecutor.Config.GetString("scaleio.thinOrThick")
+	if thinOrThick == "" {
+		return "ThinProvisioned"
+	}
+	return thinOrThick
+}
+
+func (d *driver) version() string {
+	return d.StorageExecutor.Config.GetString("scaleio.version")
+}
+
+func ef() goof.Fields {
+	return goof.Fields{
+		"provider": Name,
+	}
+}

--- a/drivers/storage/scaleio/scaleio_nodriver.go
+++ b/drivers/storage/scaleio/scaleio_nodriver.go
@@ -1,0 +1,109 @@
+// +build scaleio
+// +build !driver
+
+package scaleio
+
+import (
+	"github.com/emccode/libstorage/api/types"
+	"github.com/emccode/libstorage/api/types/context"
+	"github.com/emccode/libstorage/api/types/drivers"
+)
+
+func (d *driver) NextDeviceInfo() *types.NextDeviceInfo {
+	return nil
+}
+
+func (d *driver) InstanceInspect(
+	ctx context.Context,
+	opts types.Store) (*types.Instance, error) {
+	return nil, nil
+}
+
+func (d *driver) Volumes(
+	ctx context.Context,
+	opts *drivers.VolumesOpts) ([]*types.Volume, error) {
+	return nil, nil
+}
+
+func (d *driver) VolumeInspect(
+	ctx context.Context,
+	volumeID string,
+	opts *drivers.VolumeInspectOpts) (*types.Volume, error) {
+	return nil, nil
+}
+
+func (d *driver) VolumeCreate(
+	ctx context.Context,
+	name string,
+	opts *drivers.VolumeCreateOpts) (*types.Volume, error) {
+	return nil, nil
+}
+
+func (d *driver) VolumeCreateFromSnapshot(
+	ctx context.Context,
+	snapshotID, volumeName string,
+	opts types.Store) (*types.Volume, error) {
+	return nil, nil
+}
+
+func (d *driver) VolumeCopy(
+	ctx context.Context,
+	volumeID, volumeName string,
+	opts types.Store) (*types.Volume, error) {
+	return nil, nil
+}
+
+func (d *driver) VolumeSnapshot(
+	ctx context.Context,
+	volumeID, snapshotName string,
+	opts types.Store) (*types.Snapshot, error) {
+	return nil, nil
+}
+
+func (d *driver) VolumeRemove(
+	ctx context.Context,
+	volumeID string,
+	opts types.Store) error {
+	return nil
+}
+
+func (d *driver) VolumeAttach(
+	ctx context.Context,
+	volumeID string,
+	opts *drivers.VolumeAttachByIDOpts) (*types.Volume, error) {
+	return nil, nil
+}
+
+func (d *driver) VolumeDetach(
+	ctx context.Context,
+	volumeID string,
+	opts types.Store) error {
+	return nil
+}
+
+func (d *driver) Snapshots(
+	ctx context.Context,
+	opts types.Store) ([]*types.Snapshot, error) {
+	return nil, nil
+}
+
+func (d *driver) SnapshotInspect(
+	ctx context.Context,
+	snapshotID string,
+	opts types.Store) (*types.Snapshot, error) {
+	return nil, nil
+}
+
+func (d *driver) SnapshotCopy(
+	ctx context.Context,
+	snapshotID, snapshotName, destinationID string,
+	opts types.Store) (*types.Snapshot, error) {
+	return nil, nil
+}
+
+func (d *driver) SnapshotRemove(
+	ctx context.Context,
+	snapshotID string,
+	opts types.Store) error {
+	return nil
+}

--- a/drivers/storage/scaleio/scaleio_noop.go
+++ b/drivers/storage/scaleio/scaleio_noop.go
@@ -1,0 +1,3 @@
+// +build !scaleio
+
+package scaleio

--- a/drivers/storage/scaleio/test_server/scaleio_test_server.go
+++ b/drivers/storage/scaleio/test_server/scaleio_test_server.go
@@ -1,0 +1,196 @@
+// +build run
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/akutz/gofig"
+	"github.com/akutz/gotil"
+
+	// load the driver
+	"github.com/emccode/libstorage"
+	_ "github.com/emccode/libstorage/drivers/storage/scaleio"
+	"github.com/emccode/libstorage/drivers/storage/scaleio/executor"
+)
+
+func main() {
+
+	// make sure all servers get closed even if the test is abrubptly aborted
+	trapAbort()
+
+	if debug, _ := strconv.ParseBool(os.Getenv("LIBSTORAGE_DEBUG")); debug {
+		log.SetLevel(log.DebugLevel)
+		os.Setenv("LIBSTORAGE_SERVER_HTTP_LOGGING_ENABLED", "true")
+		os.Setenv("LIBSTORAGE_SERVER_HTTP_LOGGING_LOGREQUEST", "true")
+		os.Setenv("LIBSTORAGE_SERVER_HTTP_LOGGING_LOGRESPONSE", "true")
+		os.Setenv("LIBSTORAGE_CLIENT_HTTP_LOGGING_ENABLED", "true")
+		os.Setenv("LIBSTORAGE_CLIENT_HTTP_LOGGING_LOGREQUEST", "true")
+		os.Setenv("LIBSTORAGE_CLIENT_HTTP_LOGGING_LOGRESPONSE", "true")
+	}
+
+	serve("", false)
+}
+
+func trapAbort() {
+	// make sure all servers get closed even if the test is abrubptly aborted
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc,
+		syscall.SIGKILL,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT)
+	go func() {
+		<-sigc
+		fmt.Println("received abort signal")
+		closeAllServers()
+		fmt.Println("all servers closed")
+		os.Exit(1)
+	}()
+}
+
+var servers []io.Closer
+
+func closeAllServers() bool {
+	noErrors := true
+	for _, server := range servers {
+		if err := server.Close(); err != nil {
+			noErrors = false
+			fmt.Printf("error closing server: %v\n", err)
+		}
+	}
+	return noErrors
+}
+
+func serve(host string, tls bool) {
+
+	if host == "" {
+		host = fmt.Sprintf("tcp://localhost:%d", gotil.RandomTCPPort())
+	}
+	config := getConfig(host, tls)
+	server, errs := libstorage.Serve(config)
+	if server != nil {
+		servers = append(servers, server)
+	}
+	<-errs
+}
+
+func getConfig(host string, tls bool) gofig.Config {
+	if host == "" {
+		host = "tcp://127.0.0.1:7979"
+	}
+	config := gofig.New()
+
+	scaleioConfig := map[string]interface{}{
+		"endpoint":             "https://192.168.50.12/api",
+		"insecure":             true,
+		"useCerts":             false,
+		"userName":             "admin",
+		"password":             "Scaleio123",
+		"systemID":             "6cfe25856a90658d",
+		"systemName":           "cluster1",
+		"protectionDomainID":   "6d13747300000000",
+		"protectionDomainName": "pdomain",
+		"storagePoolID":        "672d836d00000000",
+		"storagePoolName":      "pool1",
+		"thinOrThick":          "ThinProvisioned",
+		"version":              "2.0",
+	}
+	config.Set("scaleio", scaleioConfig)
+
+	var clientTLS, serverTLS string
+	if tls {
+		clientTLS = fmt.Sprintf(
+			libStorageConfigClientTLS,
+			clientCrt, clientKey, trustedCerts)
+		serverTLS = fmt.Sprintf(
+			libStorageConfigServerTLS,
+			serverCrt, serverKey, trustedCerts)
+	}
+	configYaml := fmt.Sprintf(
+		libStorageConfigBase,
+		host,
+    "/tmp/libstorage/executors",
+		clientTLS,
+    serverTLS,
+		serviceName,
+    executor.Name)
+	fmt.Printf("Config YML %+v", configYaml)
+
+	configYamlBuf := []byte(configYaml)
+	if err := config.ReadConfig(bytes.NewReader(configYamlBuf)); err != nil {
+		panic(err)
+	}
+  return config
+}
+
+var (
+	tlsPath = fmt.Sprintf(
+		"%s/src/github.com/emccode/libstorage/.tls", os.Getenv("GOPATH"))
+	serverCrt    = fmt.Sprintf("%s/libstorage-server.crt", tlsPath)
+	serverKey    = fmt.Sprintf("%s/libstorage-server.key", tlsPath)
+	clientCrt    = fmt.Sprintf("%s/libstorage-client.crt", tlsPath)
+	clientKey    = fmt.Sprintf("%s/libstorage-client.key", tlsPath)
+	trustedCerts = fmt.Sprintf("%s/libstorage-ca.crt", tlsPath)
+)
+
+const (
+	serviceName = executor.Name
+
+	/*
+	   libStorageConfigBase is the base config for tests
+	   01 - the host address to server and which the client uses
+	   02 - the executors directory
+	   03 - the client TLS section. use an empty string if TLS is disabled
+	   04 - the server TLS section. use an empty string if TLS is disabled
+	   05 - the first service name
+	   06 - the first service's driver type
+	*/
+	libStorageConfigBase = `
+libstorage:
+  host: %[1]s
+  driver: invalidDriverName
+  executorsDir: %[2]s
+  profiles:
+    enabled: true
+    groups:
+    - local=127.0.0.1%[3]s
+  server:
+    endpoints:
+      localhost:
+        address: tcp://192.168.50.12:9000
+    services:
+      %[5]s:
+        libstorage:
+          driver: %[6]s
+          profiles:
+            enabled: true
+            groups:
+            - remote=127.0.0.1
+`
+
+	libStorageConfigClientTLS = `
+    tls:
+      serverName: libstorage-server
+      certFile: %s
+      keyFile: %s
+      trustedCertsFile: %s
+`
+
+	libStorageConfigServerTLS = `
+        tls:
+          serverName: libstorage-server
+          certFile: %s
+          keyFile: %s
+          trustedCertsFile: %s
+          clientCertRequired: true
+`
+)

--- a/drivers/storage/scaleio/tests/coverage.mk
+++ b/drivers/storage/scaleio/tests/coverage.mk
@@ -1,0 +1,2 @@
+SCALEIO_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/scaleio
+TEST_COVERPKG_./drivers/storage/scaleio/tests := $(SCALEIO_COVERPKG),$(SCALEIO_COVERPKG)/executor

--- a/drivers/storage/scaleio/tests/scaleio_test.go
+++ b/drivers/storage/scaleio/tests/scaleio_test.go
@@ -1,0 +1,143 @@
+package scaleio
+
+import (
+  "os"
+  "strconv"
+  "testing"
+  "os/exec"
+  "strings"
+
+  "github.com/akutz/gofig"
+  "github.com/stretchr/testify/assert"
+
+  "github.com/emccode/libstorage/api/server/executors"
+  apitests "github.com/emccode/libstorage/api/tests"
+  "github.com/emccode/libstorage/api/types"
+  "github.com/emccode/libstorage/client"
+
+
+  // load the  driver
+  "github.com/emccode/libstorage/drivers/storage/scaleio"
+)
+
+var (
+  lsxbin string
+
+	lsxLinuxInfo, _   = executors.ExecutorInfoInspect("lsx-linux", false)
+	lsxDarwinInfo, _  = executors.ExecutorInfoInspect("lsx-darwin", false)
+	lsxWindowsInfo, _ = executors.ExecutorInfoInspect("lsx-windows.exe", false)
+
+	configYAML = []byte(`
+libstorage:
+  host: tcp://127.0.0.1
+  driver: scaleio
+  server:
+    services:
+      scaleio:
+        endpoint:             https://192.168.50.12/api
+        insecure:             true
+        useCerts:             false
+        userName:             admin
+        password:             Scaleio123
+        systemID:             6cfe25856a90658d
+        systemName:           cluster1
+        protectionDomainID:   6d13747300000000
+        protectionDomainName: pdomain
+        storagePoolID:        672d836d00000000
+        storagePoolName:      pool1
+        thinOrThick:          ThinProvisioned
+        version:              2.0
+
+scaleio:
+  endpoint:             https://192.168.50.12/api
+  insecure:             true
+  useCerts:             false
+  userName:             admin
+  password:             Scaleio123
+  systemID:             6cfe25856a90658d
+  systemName:           cluster1
+  protectionDomainID:   6d13747300000000
+  protectionDomainName: pdomain
+  storagePoolID:        672d836d00000000
+  storagePoolName:      pool1
+  thinOrThick:          ThinProvisioned
+  version:              2.0
+`)
+)
+
+func init() {
+  if travis, _ := strconv.ParseBool(os.Getenv("TRAVIS")); !travis {
+    // semaphore.Unlink(types.LSX)
+  }
+}
+
+func TestMain(m *testing.M) {
+  ec := m.Run()
+  client.Close()
+  os.Exit(ec)
+}
+
+func TestClient(t *testing.T) {
+  apitests.Run(t, scaleio.Name, configYAML,
+    func(config gofig.Config, client client.Client, t *testing.T) {
+      iid, err := client.InstanceID(scaleio.Name)
+      assert.NoError(t, err)
+      assert.NotNil(t, iid)
+    })
+}
+
+func TestInstanceID(t *testing.T) {
+  apitests.RunGroup(
+    t, scaleio.Name, configYAML,
+    (&apitests.InstanceIDTest{
+     Driver:   scaleio.Name,
+     Expected: getSdcLocalGUID(),
+    }).Test)
+}
+
+func TestRoot(t *testing.T) {
+  apitests.Run(t, scaleio.Name, configYAML, apitests.TestRoot)
+}
+
+func TestServices(t *testing.T) {
+  tf := func(config gofig.Config, client client.Client, t *testing.T) {
+    reply, err := client.API().Services(nil)
+    assert.NoError(t, err)
+    assert.Equal(t, len(reply), 1)
+
+    _, ok := reply[scaleio.Name]
+    assert.True(t, ok)
+  }
+  apitests.Run(t, scaleio.Name, configYAML, tf)
+}
+
+func TestServiceInspect(t *testing.T) {
+  tf := func(config gofig.Config, client client.Client, t *testing.T) {
+    reply, err := client.API().ServiceInspect(nil, "scaleio")
+    assert.NoError(t, err)
+    assert.Equal(t, "scaleio", reply.Name)
+    assert.Equal(t, "scaleio", reply.Driver.Name)
+  }
+  apitests.Run(t, scaleio.Name, configYAML, tf)
+}
+
+
+//////////////////////
+///  Test Helpers  ///
+//////////////////////
+
+
+func getSdcLocalGUID() *types.InstanceID {
+  // get sdc kernel guid
+  // /bin/emc/scaleio/drv_cfg --query_guid
+  // sdcKernelGuid := "271bad82-08ee-44f2-a2b1-7e2787c27be1"
+
+  out, err := exec.Command("/opt/emc/scaleio/sdc/bin/drv_cfg", "--query_guid").Output()
+  if err != nil {
+    return &types.InstanceID{}
+  }
+  sdcGUID := strings.Replace(string(out), "\n", "", -1)
+  return &types.InstanceID{
+    ID:   sdcGUID,
+  }
+}

--- a/imports/executors/imports_executor.go
+++ b/imports/executors/imports_executor.go
@@ -8,7 +8,7 @@ import (
 	_ "github.com/emccode/libstorage/drivers/storage/mock/executor"
 	//_ "github.com/emccode/libstorage/drivers/storage/openstack/executor"
 	//_ "github.com/emccode/libstorage/drivers/storage/rackspace/executor"
-	//_ "github.com/emccode/libstorage/drivers/storage/scaleio/executor"
+	_ "github.com/emccode/libstorage/drivers/storage/scaleio/executor"
 	//_ "github.com/emccode/libstorage/drivers/storage/vbox/executor"
 	_ "github.com/emccode/libstorage/drivers/storage/vfs/executor"
 	//_ "github.com/emccode/libstorage/drivers/storage/vmax/executor"

--- a/imports/remote/imports_remote.go
+++ b/imports/remote/imports_remote.go
@@ -1,7 +1,7 @@
 package remote
 
 import (
-	// import to load
-	_ "github.com/emccode/libstorage/drivers/storage/mock"
-	_ "github.com/emccode/libstorage/drivers/storage/vfs/storage"
+  _ "github.com/emccode/libstorage/drivers/storage/mock"
+  _ "github.com/emccode/libstorage/drivers/storage/vfs/storage"
+  _ "github.com/emccode/libstorage/drivers/storage/scaleio"
 )


### PR DESCRIPTION
## Introduce ScaleIO Executor & Driver to LibStorage

**List of Deliverables:**

*Executor*
- [x] Get InstanceID (Local SDC GUID) 
- [x] Get Attached ScaleIO Devices 
- [x] Get NextDevice ID

*Driver*

- [x] Initialize Driver with ScaleIO Gateway
- [x] Inspect a Specific Volume
- [x] Create a Volume
- [x] Remove a Volume
- [x] Attach a Volume
- [x] Detach a Volume
- [ ] Copy Volume
- [ ] Inspect All Snapshots
- [ ] Inspect a Specific Snapshot
- [ ] Snapshot a Volume
- [ ] Copy a Snapshot
- [ ] Remove a Snapshot
- [ ] Create Volume From Snapshot

*Tests*

- [x] Main Function 
- [x] Create Client
- [x] InstanceID
- [x] Root List
- [x] List Services
- [x] Service Inspect
- [x] Create Volume (In Volume Workflow)
- [x] Inspect Volumes (In Volume Workflow)
- [x] Inspect Specific Volume (In Volume Workflow)
- [x] Delete Volume (In Volume Workflow)
- [ ] Attach Volume
- [ ] Detach Volume
- [ ] Copy Volume
- [ ] Inspect All Snapshots
- [ ] Inspect a Specific Snapshot
- [ ] Snapshot a Volume
- [ ] Create Volume From Snapshot

**General Information:**

Executor does not utilize goScaleio library for size reduction reasons

All functionality tested on ScaleIO 2.0 unless otherwise stated.
