### PR TITLE
Semaphore Locking for Executor Downloads

### DIFF
--- a/api/tests/tests.go
+++ b/api/tests/tests.go
@@ -184,6 +184,10 @@ func (th *testHarness) run(
 
 				client, err := getClient(config)
 				assert.NoError(t, err)
+				assert.NotNil(t, client)
+				if client == nil {
+					panic(fmt.Sprintf("err=%v, client=%v", err, client))
+				}
 
 				for _, test := range tests {
 					test(config, client, t)
@@ -215,6 +219,11 @@ func (th *testHarness) run(
 
 					client, err := getClient(config)
 					assert.NoError(t, err)
+					assert.NotNil(t, client)
+
+					if client == nil {
+						panic(fmt.Sprintf("err=%v, client=%v", err, client))
+					}
 
 					test(config, client, t)
 				}(test, x, config)
@@ -292,7 +301,6 @@ func getClient(config gofig.Config) (client.Client, error) {
 			"host", config.Get("libstorage.host"),
 			"error dialing libStorage service", err)
 	}
-
 	return c, nil
 }
 

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -1,0 +1,17 @@
+package types
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// LSX is the default  name of the libStorage executor for the current OS.
+var LSX string
+
+func init() {
+	if runtime.GOOS == "windows" {
+		LSX = "lsx-windows.exe"
+	} else {
+		LSX = fmt.Sprintf("lsx-%s", runtime.GOOS)
+	}
+}

--- a/api/utils/semaphore/semaphore.go
+++ b/api/utils/semaphore/semaphore.go
@@ -1,0 +1,63 @@
+package semaphore
+
+import (
+	"os"
+	"time"
+)
+
+// Semaphore enables processes and threads to synchronize their actions.
+type Semaphore interface {
+
+	// Name returns the name of the semaphore.
+	Name() string
+
+	// Close closes the semaphore.
+	Close() error
+
+	// Signal increments (unlocks) the semaphore pointed to by sem.  If
+	// the semaphore's value consequently becomes greater than zero, then
+	// another process or thread blocked in a Wait() call will be woken
+	// up and proceed to lock the semaphore.
+	Signal() error
+
+	// Wait decrements (locks) the semaphore pointed to by sem.  If
+	// the semaphore's value is greater than zero, then the decrement
+	// proceeds, and the function returns, immediately.  If the semaphore
+	// currently has the value zero, then the call blocks until either it
+	// becomes possible to perform the decrement (i.e., the semaphore value
+	// ises above zero), or a signal handler interrupts the call.
+	Wait() error
+
+	// TryWait is the same as Wait(), except that if the decrement
+	// cannot be immediately performed, then call returns a true flag and
+	// no error.
+	TryWait() (bool, error)
+
+	// TimedWait is the same as Wait(), except that abs_timeout
+	// specifies a limit on the amount of time that the call should block if
+	// the decrement cannot be immediately performed.
+	TimedWait(timeout *time.Time) error
+
+	// Value returns the current value of the semaphore. If one or more
+	// processes or threads are blocked waiting to lock the
+	// semaphore with Wait(), POSIX.1 permits two possibilities for the
+	// value returned in sval: either 0 is returned; or a negative number
+	// whose absolute value is the count of the number of processes and
+	// threads currently blocked in Wait().  Linux adopts the former
+	// behavior.
+	Value() (int, error)
+}
+
+// Open creates a new, named semaphore or opens an existing one if one exists
+// with the given name.
+func Open(
+	name string, excl bool, perm os.FileMode, val int) (Semaphore, error) {
+	return open(name, excl, perm, val)
+}
+
+// Unlink removes the named semaphore referred to by name. The semaphore name
+// is removed immediately. The semaphore is destroyed once all other processes
+// that have the semaphore open close it.
+func Unlink(name string) error {
+	return unlink(name)
+}

--- a/api/utils/semaphore/semaphore_darwin.go
+++ b/api/utils/semaphore/semaphore_darwin.go
@@ -1,0 +1,15 @@
+package semaphore
+
+import (
+	"time"
+
+	"github.com/akutz/goof"
+)
+
+func (s *semaphore) timedWait(t *time.Time) error {
+	return goof.New("unsupported")
+}
+
+func (s *semaphore) value() (int, error) {
+	return int(s.count), nil
+}

--- a/api/utils/semaphore/semaphore_linux.go
+++ b/api/utils/semaphore/semaphore_linux.go
@@ -1,0 +1,64 @@
+package semaphore
+
+// #include <fcntl.h>           /* For O_* constants */
+// #include <sys/stat.h>        /* For mode constants */
+// #include <semaphore.h>
+// #include <string.h>
+// #include <stdlib.h>
+// #include <errno.h>
+/*
+typedef struct {
+    sem_t*      val;
+    int         err;
+} sem_tt;
+
+int _sem_timedwait(void* sem, time_t sec, long nsec) {
+	struct timespec* ts = (struct timespec*)malloc(sizeof(struct timespec));
+    ts->tv_sec = sec;
+    ts->tv_nsec = nsec;
+	const struct timespec* cts = (const struct timespec*) ts;
+	while (sem_timedwait(((sem_tt*)sem)->val, cts))
+		if (errno == EINTR) errno = 0;
+		else return errno;
+	return 0;
+}
+
+typedef struct {
+	int     ret;
+	int     val;
+} getvalue_result;
+
+getvalue_result* _sem_getvalue(void* sem) {
+	getvalue_result* r = (getvalue_result*)malloc(sizeof(getvalue_result));
+	r->ret = sem_getvalue(((sem_tt*)sem)->val, &(r->val)) == 0 ? 0 : errno;
+	return r;
+}
+*/
+import "C"
+import (
+	"time"
+
+	"github.com/akutz/goof"
+)
+
+func (s *semaphore) timedWait(t *time.Time) error {
+	err := C._sem_timedwait(s.sema, C.time_t(t.Unix()), C.long(t.UnixNano()))
+	if err == 0 {
+		return nil
+	}
+	return goof.WithFields(goof.Fields{
+		"name":  s.name,
+		"error": int(err),
+	}, "error timed waiting on semaphore")
+}
+
+func (s *semaphore) value() (int, error) {
+	r := C._sem_getvalue(s.sema)
+	if r.ret == 0 {
+		return int(r.val), nil
+	}
+	return 0, goof.WithFields(goof.Fields{
+		"name":  s.name,
+		"error": int(r.ret),
+	}, "error getting semaphore value")
+}

--- a/api/utils/semaphore/semaphore_test.go
+++ b/api/utils/semaphore/semaphore_test.go
@@ -1,0 +1,93 @@
+package semaphore
+
+import (
+	"os"
+	"testing"
+
+	"github.com/akutz/goof"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/emccode/libstorage/api/types"
+)
+
+var (
+	name = types.LSX
+)
+
+func init() {
+	goof.IncludeFieldsInFormat = true
+}
+
+func TestMain(m *testing.M) {
+	Unlink(name)
+	ec := m.Run()
+	Unlink(name)
+	os.Exit(ec)
+}
+
+func TestOpenClose(t *testing.T) {
+	s, err := Open(name, true, 0644, 0)
+	assert.NoError(t, err)
+
+	_, err = Open(name, true, 0644, 0)
+	assert.Error(t, err)
+	gerr := err.(goof.Goof)
+	assert.EqualValues(t, gerr.Fields()["error"], 17)
+
+	closeAndUnlink(t, s)
+}
+
+func TestTryWait(t *testing.T) {
+	s, err := Open(name, true, 0644, 0)
+	assert.NoError(t, err)
+
+	ea, err := s.TryWait()
+	assert.True(t, ea)
+	assert.NoError(t, err)
+
+	assert.NoError(t, s.Signal())
+	ea, err = s.TryWait()
+	assert.False(t, ea)
+	assert.NoError(t, err)
+
+	closeAndUnlink(t, s)
+}
+
+func TestWait(t *testing.T) {
+	s, err := Open(name, true, 0644, 1)
+	assert.NoError(t, err)
+	v, err := s.Value()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, v)
+
+	assert.NoError(t, s.Wait())
+	setYet := false
+	c1 := make(chan int)
+	c2 := make(chan int)
+
+	f1 := func() {
+		<-c1
+		assert.False(t, setYet)
+		assert.NoError(t, s.Signal())
+	}
+
+	f2 := func() {
+		c1 <- 1
+		assert.NoError(t, s.Wait())
+		setYet = true
+		c2 <- 1
+	}
+
+	go f1()
+	go f2()
+	<-c2
+
+	v, err = s.Value()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, v)
+}
+
+func closeAndUnlink(t *testing.T, s Semaphore) {
+	assert.NoError(t, s.Close())
+	assert.NoError(t, Unlink(s.Name()))
+}

--- a/api/utils/semaphore/semaphore_unix.go
+++ b/api/utils/semaphore/semaphore_unix.go
@@ -1,0 +1,189 @@
+// +build linux darwin
+
+package semaphore
+
+// #include <fcntl.h>           /* For O_* constants */
+// #include <sys/stat.h>        /* For mode constants */
+// #include <semaphore.h>
+// #include <string.h>
+// #include <stdlib.h>
+// #include <errno.h>
+// #include <stdio.h>
+/*
+int _errno() {
+    return errno;
+}
+
+typedef struct {
+    sem_t*      val;
+    int         err;
+} sem_tt;
+
+sem_tt* _sem_open(char* name, int flags, mode_t perm, unsigned int val) {
+    sem_tt* r = (sem_tt*)malloc(sizeof(sem_tt));
+    sem_t* sem = sem_open((const char*)name, flags, perm, val);
+	if (sem == SEM_FAILED) r->err = errno;
+    else { r->err = 0; r->val = sem; }
+    return r;
+}
+
+int _sem_close(void* sem) {
+    return sem_close(((sem_tt*)sem)->val) == 0 ? 0 : errno;
+}
+
+int _sem_wait(void* sem) {
+	while (sem_wait(((sem_tt*)sem)->val))
+		if (errno == EINTR) errno = 0;
+		else return errno;
+	return 0;
+}
+
+int _sem_trywait(void* sem) {
+    while (sem_trywait(((sem_tt*)sem)->val))
+		if (errno == EINTR) errno = 0;
+		else return errno;
+	return 0;
+}
+
+int _sem_post(void* sem) {
+    return sem_post(((sem_tt*)sem)->val) == 0 ? 0 : errno;
+}
+
+int _sem_unlink(char* name) {
+    return sem_unlink((const char*) name) == 0 ? 0 : errno;
+}
+
+int* pInt() {
+    int* val = (int*)malloc(sizeof(int));
+    return val;
+}
+
+const char* cpchar(char* val) {
+    return (const char*)val;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"github.com/akutz/goof"
+)
+
+type semaphore struct {
+	name  string
+	sema  unsafe.Pointer
+	count int64
+}
+
+func open(
+	name string, excl bool, perm os.FileMode, val int) (Semaphore, error) {
+
+	if !strings.HasPrefix(name, `/`) {
+		name = fmt.Sprintf("/%s", name)
+	}
+	cs := C.CString(name)
+
+	flags := C.O_CREAT
+	if excl {
+		flags = flags | C.O_EXCL
+	}
+
+	sema := C._sem_open(cs, C.int(flags), C.mode_t(perm), C.uint(val))
+	if sema.err != 0 {
+		return nil, goof.WithFields(goof.Fields{
+			"name":  name,
+			"error": sema.err,
+		}, "error opening semaphore")
+	}
+
+	C.free(unsafe.Pointer(cs))
+
+	return &semaphore{
+		name:  name,
+		sema:  unsafe.Pointer(sema),
+		count: int64(val),
+	}, nil
+}
+
+func (s *semaphore) Name() string {
+	return s.name
+}
+
+func (s *semaphore) Close() error {
+	err := C._sem_close(s.sema)
+	if err == 0 {
+		return nil
+	}
+	return goof.WithFields(goof.Fields{
+		"name":  s.name,
+		"error": int(err),
+	}, "error closing semaphore")
+}
+
+func (s *semaphore) Signal() error {
+	err := C._sem_post(s.sema)
+	if err == 0 {
+		atomic.AddInt64(&s.count, 1)
+		return nil
+	}
+	return goof.WithFields(goof.Fields{
+		"name":  s.name,
+		"error": int(err),
+	}, "error unlocking semaphore")
+}
+
+func (s *semaphore) Value() (int, error) {
+	return s.value()
+}
+
+func (s *semaphore) Wait() error {
+	err := C._sem_wait(s.sema)
+	if err == 0 {
+		atomic.AddInt64(&s.count, -1)
+		return nil
+	}
+	return goof.WithFields(goof.Fields{
+		"name":  s.name,
+		"error": int(err),
+	}, "error waiting on semaphore")
+}
+
+func (s *semaphore) TryWait() (bool, error) {
+	err := C._sem_trywait(s.sema)
+	if err == 0 {
+		atomic.AddInt64(&s.count, -1)
+		return false, nil
+	} else if err == C.EAGAIN {
+		return true, nil
+	}
+	return false, goof.WithFields(goof.Fields{
+		"name":  s.name,
+		"error": int(err),
+	}, "error trying wait on semaphore")
+}
+
+func (s *semaphore) TimedWait(t *time.Time) error {
+	return s.timedWait(t)
+}
+
+func unlink(name string) error {
+	if !strings.HasPrefix(name, `/`) {
+		name = fmt.Sprintf("/%s", name)
+	}
+	cs := C.CString(name)
+	err := C._sem_unlink(cs)
+	C.free(unsafe.Pointer(cs))
+	if err == 0 {
+		return nil
+	}
+	return goof.WithFields(goof.Fields{
+		"name":  name,
+		"error": int(err),
+	}, "error unlinking semaphore")
+}

--- a/api/utils/semaphore/semaphore_windows.go
+++ b/api/utils/semaphore/semaphore_windows.go
@@ -1,0 +1,12 @@
+package semaphore
+
+import (
+	"os"
+
+	"github.com/akutz/goof"
+)
+
+func open(
+	name string, excl bool, perm os.FileMode, val uint) (Semaphore, error) {
+	return nil, goof.New("unsupported")
+}

--- a/cli/executors/executors.go
+++ b/cli/executors/executors.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"runtime"
 	"strings"
 
 	"github.com/emccode/libstorage/api/registry"
@@ -40,19 +39,8 @@ const (
 )
 
 var (
-	// LSX is the default  name of the libStorage executor for the current OS.
-	LSX string
-
 	cmdRx = regexp.MustCompile("(?i)instanceid|nextdevice|localdevices")
 )
-
-func init() {
-	if runtime.GOOS == "windows" {
-		LSX = "lsx-windows.exe"
-	} else {
-		LSX = fmt.Sprintf("lsx-%s", runtime.GOOS)
-	}
-}
 
 // Run runs the executor CLI.
 func Run() {

--- a/client/client_executor.go
+++ b/client/client_executor.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/akutz/goof"
+	"github.com/akutz/gotil"
+
+	"github.com/emccode/libstorage/api/types"
+)
+
+func (c *lsc) updateExecutorInfo() error {
+	c.ctx.Log().Debug("getting executor information")
+	lsxInfo, err := c.Client.Executors(c.ctx)
+	if err != nil {
+		return err
+	}
+	c.lsxInfo = lsxInfo
+	return nil
+}
+
+func (c *lsc) updateExecutor() error {
+	lsxi, ok := c.lsxInfo[types.LSX]
+	if !ok {
+		return goof.WithField("lsx", types.LSX, "unknown executor")
+	}
+
+	c.ctx.Log().Debug("waiting on executor lock")
+	if err := lsxMutex.Wait(); err != nil {
+		return err
+	}
+	defer func() {
+		c.ctx.Log().Debug("signalling executor lock")
+		if err := lsxMutex.Signal(); err != nil {
+			panic(err)
+		}
+	}()
+
+	if !gotil.FileExists(c.lsxBinPath) {
+		return c.downloadExecutor()
+	}
+
+	checksum, err := c.getExecutorChecksum()
+	if err != nil {
+		return err
+	}
+
+	if lsxi.MD5Checksum != checksum {
+		return c.downloadExecutor()
+	}
+
+	return nil
+}
+
+func (c *lsc) getExecutorChecksum() (string, error) {
+	f, err := os.Open(c.lsxBinPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := md5.New()
+	buf := make([]byte, 1024)
+	for {
+		n, err := f.Read(buf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+		if _, err := h.Write(buf[:n]); err != nil {
+			return "", err
+		}
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func (c *lsc) downloadExecutor() error {
+
+	f, err := os.OpenFile(
+		c.lsxBinPath,
+		os.O_CREATE|os.O_RDWR|os.O_TRUNC,
+		0755)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	rdr, err := c.Client.ExecutorGet(c.ctx, types.LSX)
+	if _, err := io.Copy(f, rdr); err != nil {
+		return err
+	}
+
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/drivers/storage/mock/tests/mock_test.go
+++ b/drivers/storage/mock/tests/mock_test.go
@@ -1,9 +1,8 @@
 package mock
 
 import (
-	"fmt"
 	"os"
-	"runtime"
+	"strconv"
 	"testing"
 
 	"github.com/akutz/gofig"
@@ -39,23 +38,25 @@ libstorage:
 )
 
 func init() {
-	if runtime.GOOS == "windows" {
-		lsxbin = "lsx-windows.exe"
-	} else {
-		lsxbin = fmt.Sprintf("lsx-%s", runtime.GOOS)
+	if travis, _ := strconv.ParseBool(os.Getenv("TRAVIS")); !travis {
+		// semaphore.Unlink(types.LSX)
 	}
 }
 
 func TestMain(m *testing.M) {
 	cfg, err := config.NewConfig()
 	if err != nil {
+		client.Close()
 		os.Exit(1)
 	}
 
 	lsxBinPath := cfg.GetString(client.LSXPathKey)
 	os.RemoveAll(lsxBinPath)
 
-	os.Exit(m.Run())
+	ec := m.Run()
+
+	client.Close()
+	os.Exit(ec)
 }
 
 func TestClient(t *testing.T) {


### PR DESCRIPTION
This patch uses a kernel-level semaphore to synchronize the process of downloading and executing the executor binary in order to prevent multiple threads and processes from munging access to the file.