### PR TITLE
Semaphore Memory Leak Fix

### DIFF
--- a/api/utils/semaphore/semaphore.go
+++ b/api/utils/semaphore/semaphore.go
@@ -36,7 +36,7 @@ type Semaphore interface {
 	// TimedWait is the same as Wait(), except that abs_timeout
 	// specifies a limit on the amount of time that the call should block if
 	// the decrement cannot be immediately performed.
-	TimedWait(timeout *time.Time) error
+	TimedWait(timeout time.Duration) error
 
 	// Value returns the current value of the semaphore. If one or more
 	// processes or threads are blocked waiting to lock the

--- a/api/utils/semaphore/semaphore_darwin.go
+++ b/api/utils/semaphore/semaphore_darwin.go
@@ -6,7 +6,7 @@ import (
 	"github.com/akutz/goof"
 )
 
-func (s *semaphore) timedWait(t *time.Time) error {
+func (s *semaphore) timedWait(t time.Duration) error {
 	return goof.New("unsupported")
 }
 

--- a/api/utils/semaphore/semaphore_linux_test.go
+++ b/api/utils/semaphore/semaphore_linux_test.go
@@ -1,0 +1,73 @@
+// +build linux
+
+package semaphore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetValue(t *testing.T) {
+	s, err := Open(name, true, 0644, 1)
+	assert.NoError(t, err)
+
+	v, err := s.Value()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, v)
+
+	assert.NoError(t, s.Wait())
+	assert.NoError(t, err)
+
+	v, err = s.Value()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, v)
+
+	assert.NoError(t, s.Signal())
+	assert.NoError(t, s.Signal())
+
+	v, err = s.Value()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 2, v)
+
+	closeAndUnlink(t, s)
+}
+
+func TestTimedWait(t *testing.T) {
+	s, err := Open(name, true, 0644, 1)
+	assert.NoError(t, err)
+	v, err := s.Value()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, v)
+
+	timeout := time.Duration(time.Second * 5)
+
+	assert.NoError(t, s.TimedWait(timeout))
+	setYet := false
+	c1 := make(chan int)
+	c2 := make(chan int)
+
+	f1 := func() {
+		<-c1
+		assert.False(t, setYet)
+		assert.NoError(t, s.Signal())
+	}
+
+	f2 := func() {
+		c1 <- 1
+		assert.NoError(t, s.TimedWait(timeout))
+		setYet = true
+		c2 <- 1
+	}
+
+	go f1()
+	go f2()
+	<-c2
+
+	v, err = s.Value()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, v)
+
+	closeAndUnlink(t, s)
+}

--- a/api/utils/semaphore/semaphore_test.go
+++ b/api/utils/semaphore/semaphore_test.go
@@ -28,6 +28,9 @@ func TestMain(m *testing.M) {
 func TestOpenClose(t *testing.T) {
 	s, err := Open(name, true, 0644, 0)
 	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+	}
 
 	_, err = Open(name, true, 0644, 0)
 	assert.Error(t, err)


### PR DESCRIPTION
This patch updates the semaphore code to always free the memory allocated for sem_getvalue as well as freeing the sema struct itself when the Go Semaphore interface is closed.