### PR TITLE
Fix for server name randomizer

### DIFF
--- a/api/server/server_names.go
+++ b/api/server/server_names.go
@@ -17,10 +17,10 @@ func randomServerName() string {
 		possibleServerNames["countries"][z])
 }
 
-const (
-	maxAdjectives = 527 - 1
-	maxNouns      = 364 - 1
-	maxCountries  = 249 - 1
+var (
+	maxAdjectives = len(possibleServerNames["adjectives"]) - 1
+	maxNouns      = len(possibleServerNames["nouns"]) - 1
+	maxCountries  = len(possibleServerNames["countries"]) - 1
 )
 
 var (

--- a/drivers/storage/mock/tests/mock_test.go
+++ b/drivers/storage/mock/tests/mock_test.go
@@ -12,7 +12,6 @@ import (
 	apitests "github.com/emccode/libstorage/api/tests"
 	"github.com/emccode/libstorage/api/types"
 	apihttp "github.com/emccode/libstorage/api/types/http"
-	"github.com/emccode/libstorage/api/utils/config"
 	"github.com/emccode/libstorage/client"
 
 	// load the  driver
@@ -44,17 +43,7 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
-	cfg, err := config.NewConfig()
-	if err != nil {
-		client.Close()
-		os.Exit(1)
-	}
-
-	lsxBinPath := cfg.GetString(client.LSXPathKey)
-	os.RemoveAll(lsxBinPath)
-
 	ec := m.Run()
-
 	client.Close()
 	os.Exit(ec)
 }


### PR DESCRIPTION
This patch fixes an issue where taking a random server name could panic if too many attempts were made concurrently.