### PR TITLE
The server name now shown in client-logs

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -21,4 +21,12 @@ type Client struct {
 
 	// Headers are headers to send with each HTTP request.
 	Headers http.Header
+
+	// ServerName returns the name of the server to which the client is
+	// connected. This is not the same as the host name, rather it's the
+	// randomly generated name the server creates for unique identification
+	// when the server starts for the first time. This value is updated
+	// by every request to the server that returns the server name header
+	// as part of its response.
+	ServerName string
 }

--- a/api/client/client_http.go
+++ b/api/client/client_http.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/types/context"
+	apihttp "github.com/emccode/libstorage/api/types/http"
+	"github.com/emccode/libstorage/api/utils"
 )
 
 func (c *Client) httpDo(
@@ -41,6 +43,8 @@ func (c *Client) httpDo(
 	if err != nil {
 		return nil, err
 	}
+	defer c.setServerName(res)
+
 	c.logResponse(res)
 
 	if res.StatusCode > 299 {
@@ -58,6 +62,13 @@ func (c *Client) httpDo(
 	}
 
 	return res, nil
+}
+
+func (c *Client) setServerName(res *http.Response) {
+	snh := utils.GetHeader(res.Header, apihttp.ServerNameHeader)
+	if len(snh) > 0 {
+		c.ServerName = snh[0]
+	}
 }
 
 func (c *Client) httpGet(

--- a/api/server/handlers/handlers_instanceid.go
+++ b/api/server/handlers/handlers_instanceid.go
@@ -8,10 +8,10 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/emccode/libstorage/api/server/httputils"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/types/context"
 	apihttp "github.com/emccode/libstorage/api/types/http"
+	"github.com/emccode/libstorage/api/utils"
 )
 
 // instanceIDHandler is a global HTTP filter for grokking the InstanceIDs
@@ -46,7 +46,7 @@ func (h *instanceIDHandler) Handle(
 	if err := parseInstanceIDHeaders(
 		ctx,
 		apihttp.InstanceIDHeader,
-		httputils.GetHeader(req.Header, apihttp.InstanceIDHeader),
+		utils.GetHeader(req.Header, apihttp.InstanceIDHeader),
 		valMap); err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func (h *instanceIDHandler) Handle(
 	if err := parseInstanceIDHeaders(
 		ctx,
 		apihttp.InstanceID64Header,
-		httputils.GetHeader(req.Header, apihttp.InstanceID64Header),
+		utils.GetHeader(req.Header, apihttp.InstanceID64Header),
 		valMap); err != nil {
 		return err
 	}

--- a/api/server/handlers/handlers_local_devices.go
+++ b/api/server/handlers/handlers_local_devices.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 
 	"github.com/akutz/gotil"
-	"github.com/emccode/libstorage/api/server/httputils"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/types/context"
 	apihttp "github.com/emccode/libstorage/api/types/http"
+	"github.com/emccode/libstorage/api/utils"
 )
 
 // localDevicesHandler is a global HTTP filter for grokking the local devices
@@ -43,7 +43,7 @@ func (h *localDevicesHandler) Handle(
 	req *http.Request,
 	store types.Store) error {
 
-	headers := httputils.GetHeader(req.Header, apihttp.LocalDevicesHeader)
+	headers := utils.GetHeader(req.Header, apihttp.LocalDevicesHeader)
 	ctx.Log().WithField(
 		apihttp.LocalDevicesHeader, headers).Debug("http header")
 

--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -23,16 +23,6 @@ var (
 		(*drivers.RemoteStorageDriver)(nil))
 )
 
-// GetHeader is a case-insensitive way to retrieve a header's value.
-func GetHeader(headers http.Header, name string) []string {
-	for k, v := range headers {
-		if strings.ToLower(k) == strings.ToLower(name) {
-			return v
-		}
-	}
-	return nil
-}
-
 // GetService gets the Service instance from a context.
 func GetService(ctx context.Context) (apisvcs.StorageService, error) {
 	serviceObj := ctx.Value(context.ContextKeyService)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -68,7 +68,7 @@ func newServer(config gofig.Config) (*server, error) {
 	}
 
 	s.ctx = s.ctx.WithContextID("server", s.name)
-	s.ctx = s.ctx.WithValue("server", s.name)
+	s.ctx = s.ctx.WithValue(context.ContextKeyServerName, s.name)
 	s.ctx.Log().Debug("initializing server")
 
 	if err := s.initEndpoints(); err != nil {
@@ -282,6 +282,8 @@ func (s *server) makeHTTPHandler(
 	route apihttp.Route) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, req *http.Request) {
+
+		w.Header().Set(apihttp.ServerNameHeader, s.name)
 
 		fctx := context.NewContext(ctx, req)
 		fctx = ctx.WithContextID("route", route.GetName())

--- a/api/server/services/services.go
+++ b/api/server/services/services.go
@@ -27,7 +27,7 @@ type serviceContainer struct {
 
 // Init initializes the services.
 func Init(ctx context.Context, config gofig.Config) error {
-	serverName := ctx.Value("server").(string)
+	serverName := ctx.ServerName()
 
 	sc := &serviceContainer{
 		taskService:     &globalTaskService{name: "global-task-service"},
@@ -62,7 +62,7 @@ func (sc *serviceContainer) Init(config gofig.Config) error {
 func getStorageServices(
 	ctx context.Context) map[string]services.StorageService {
 
-	return servicesByServer[ctx.Value("server").(string)].storageServices
+	return servicesByServer[ctx.ServerName()].storageServices
 }
 
 // GetStorageService returns the storage service specified by the given name;
@@ -125,7 +125,7 @@ func (sc *serviceContainer) initStorageServices() error {
 func getTaskService(ctx context.Context) *globalTaskService {
 	servicesByServerRWL.RLock()
 	defer servicesByServerRWL.RUnlock()
-	return servicesByServer[ctx.Value("server").(string)].taskService
+	return servicesByServer[ctx.ServerName()].taskService
 }
 
 // Tasks returns a channel on which all tasks are received.

--- a/api/tests/tests_std.go
+++ b/api/tests/tests_std.go
@@ -2,14 +2,9 @@ package tests
 
 import (
 	"encoding/json"
-	"io"
-	"io/ioutil"
-	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/akutz/gofig"
-	"github.com/akutz/gotil"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/emccode/libstorage/api/types"
@@ -73,25 +68,10 @@ func (tt *NextDeviceTest) Test(
 	client client.Client,
 	t *testing.T) {
 
-	reply, err := client.API().ExecutorGet(nil, lsxbin)
-	assert.NoError(t, err)
-	defer reply.Close()
-
-	f, err := ioutil.TempFile("", "")
+	val, err := client.NextDevice(tt.Driver)
 	assert.NoError(t, err)
 
-	_, err = io.Copy(f, reply)
-	assert.NoError(t, err)
-
-	err = f.Close()
-	assert.NoError(t, err)
-
-	os.Chmod(f.Name(), 0755)
-
-	out, err := exec.Command(
-		f.Name(), tt.Driver, "nextDevice").CombinedOutput()
-	assert.NoError(t, err)
-	assert.Equal(t, tt.Expected, gotil.Trim(string(out)))
+	assert.Equal(t, tt.Expected, val)
 }
 
 // LocalDevicesTest is the test harness for testing getting the local devices.
@@ -115,24 +95,12 @@ func (tt *LocalDevicesTest) Test(
 	assert.NoError(t, err)
 	expectedJSON := string(expectedBuf)
 
-	reply, err := client.API().ExecutorGet(nil, lsxbin)
-	assert.NoError(t, err)
-	defer reply.Close()
-
-	f, err := ioutil.TempFile("", "")
+	val, err := client.LocalDevices(tt.Driver)
 	assert.NoError(t, err)
 
-	_, err = io.Copy(f, reply)
+	buf, err := json.Marshal(val)
 	assert.NoError(t, err)
+	actualJSON := string(buf)
 
-	err = f.Close()
-	assert.NoError(t, err)
-
-	os.Chmod(f.Name(), 0755)
-
-	out, err := exec.Command(
-		f.Name(), tt.Driver, "localDevices").CombinedOutput()
-	assert.NoError(t, err)
-
-	assert.Equal(t, expectedJSON, gotil.Trim(string(out)))
+	assert.Equal(t, expectedJSON, actualJSON)
 }

--- a/api/types/http/http_headers.go
+++ b/api/types/http/http_headers.go
@@ -10,4 +10,10 @@ const (
 
 	// LocalDevicesHeader is the HTTP header that contains a local device pair.
 	LocalDevicesHeader = "libstorage-localdevices"
+
+	// ServerNameHeader is the HTTP header that contains the randomly generated
+	// name the server creates for unique identification when the server starts
+	// for the first time. This header is provided with every response sent
+	// from the server.
+	ServerNameHeader = "libstorage-servername"
 )

--- a/api/types/types_context.go
+++ b/api/types/types_context.go
@@ -28,11 +28,16 @@ const (
 	ContextKeyLocalDevices = "localDevices"
 	// ContextKeyLocalDevicesByService is a context key.
 	ContextKeyLocalDevicesByService = "localDevicesByService"
+	// ContextKeyServerName is a context key.
+	ContextKeyServerName = "serverName"
 )
 
 // Context is a libStorage context.
 type Context interface {
 	context.Context
+
+	// ServerName gets the server name.
+	ServerName() string
 
 	// InstanceIDsByService returns the context's service to instance ID map.
 	InstanceIDsByService() map[string]*InstanceID

--- a/api/utils/utils.go
+++ b/api/utils/utils.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"fmt"
+	"net/http"
 	"reflect"
+	"strings"
 
 	_ "github.com/akutz/golf"
 )
@@ -20,4 +22,14 @@ func GetTypePkgPathAndName(i interface{}) string {
 		return typeName
 	}
 	return fmt.Sprintf("%s.%s", pkgPath, typeName)
+}
+
+// GetHeader is a case-insensitive way to retrieve a header's value.
+func GetHeader(headers http.Header, name string) []string {
+	for k, v := range headers {
+		if strings.ToLower(k) == strings.ToLower(name) {
+			return v
+		}
+	}
+	return nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -24,6 +24,12 @@ var (
 // Client is the libStorage client.
 type Client interface {
 
+	// ServerName returns the name of the server to which the client is
+	// connected. This is not the same as the host name, rather it's the
+	// randomly generated name the server creates for unique identification
+	// when the server starts for the first time.
+	ServerName() string
+
 	// API returns the underlying API client.
 	API() *apiclient.Client
 
@@ -32,6 +38,9 @@ type Client interface {
 
 	// LocalDevices gets the client's local devices map.
 	LocalDevices(service string) (map[string]string, error)
+
+	// NextDevice gets the next available device ID.
+	NextDevice(service string) (string, error)
 
 	// Services returns a map of the configured Services.
 	Services() (apihttp.ServicesMap, error)

--- a/client/client_init.go
+++ b/client/client_init.go
@@ -126,6 +126,8 @@ func New(config gofig.Config) (Client, error) {
 		return nil, err
 	}
 
+	c.ctx = c.ctx.WithContextID("server", c.ServerName())
+
 	if !config.GetBool(lsxOffline) {
 		if err := c.updateExecutorInfo(); err != nil {
 			return nil, err
@@ -156,6 +158,10 @@ func Close() error {
 
 func (c *lsc) API() *apiclient.Client {
 	return &c.Client
+}
+
+func (c *lsc) ServerName() string {
+	return c.Client.ServerName
 }
 
 func getHost(proto, lAddr string, tlsConfig *tls.Config) string {


### PR DESCRIPTION
This patch updates the libStorage client so that its context is updated with the name of the server to which it's connected. This enables all client-side logs to reflect the server name the same way server-side logs do.
### Test Run 1 - Server Side Logs
```
DEBU[0001] http header                                   host=unix:///var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/443891520.sock libstorage-instanceid64=[] route=executors server=thunder-lancer-ml tls=true user=libstorage-client
DEBU[0001] http header                                   host=unix:///var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/443891520.sock libstorage-localdevices=[] route=executors server=thunder-lancer-ml tls=true user=libstorage-client
DEBU[0001] http request                                  host=tcp://127.0.0.1:57387 route=executors server=foul-wizard-gf tls=true
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:57387 middleware=local-devices-handler route=executors server=foul-wizard-gf tls=true user=libstorage-client
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:57387 middleware=instanceIDs-handler route=executors server=foul-wizard-gf tls=true user=libstorage-client
```

### Test Run 1 - Client Side Logs
```
DEBU[0001] waiting on executor lock                      host=tcp://127.0.0.1:57387 server=foul-wizard-gf
DEBU[0001] signalling executor lock                      host=unix:///var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/069573157.sock server=candle-rat-fi
DEBU[0001] waiting on executor lock                      host=unix:///var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/069573157.sock server=candle-rat-fi
DEBU[0001] signalling executor lock                      host=tcp://127.0.0.1:41093 server=alpine-dancer-pk
DEBU[0001] waiting on executor lock                      host=tcp://127.0.0.1:41093 server=alpine-dancer-pk
DEBU[0001] signalling executor lock                      host=unix:///var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/443891520.sock server=thunder-lancer-ml
DEBU[0001] waiting on executor lock                      host=unix:///var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/443891520.sock server=thunder-lancer-ml
DEBU[0001] signalling executor lock                      host=tcp://127.0.0.1:57387 server=foul-wizard-gf
DEBU[0001] waiting on executor lock                      host=tcp://127.0.0.1:57387 server=foul-wizard-gf
```

As seen above, the client has the same contextID as the server for distinguishing between server names when multiple clients are writing to the same log stream.