### PR TITLE
Transactions

### DIFF
--- a/api/server/handlers/handlers_transaction.go
+++ b/api/server/handlers/handlers_transaction.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/emccode/libstorage/api/types"
+	"github.com/emccode/libstorage/api/types/context"
+	apihttp "github.com/emccode/libstorage/api/types/http"
+	"github.com/emccode/libstorage/api/utils"
+)
+
+// transactionHandler is a global HTTP filter for grokking the transaction info
+// from the headers
+type transactionHandler struct {
+	handler apihttp.APIFunc
+}
+
+// NewTransactionHandler returns a new global HTTP filter for grokking the
+// transaction info from the headers
+func NewTransactionHandler() apihttp.Middleware {
+	return &transactionHandler{}
+}
+
+func (h *transactionHandler) Name() string {
+	return "transaction-handler"
+}
+
+func (h *transactionHandler) Handler(m apihttp.APIFunc) apihttp.APIFunc {
+	return (&transactionHandler{m}).Handle
+}
+
+// Handle is the type's Handler function.
+func (h *transactionHandler) Handle(
+	ctx context.Context,
+	w http.ResponseWriter,
+	req *http.Request,
+	store types.Store) error {
+
+	txIDHeaders := utils.GetHeader(req.Header, apihttp.TransactionIDHeader)
+	ctx.Log().WithField(
+		apihttp.TransactionIDHeader, txIDHeaders).Debug("http header")
+
+	var txID string
+	if len(txIDHeaders) > 0 {
+		txID = txIDHeaders[0]
+	} else {
+		txIDUUID, _ := utils.NewUUID()
+		txID = txIDUUID.String()
+	}
+	ctx = ctx.WithTransactionID(txID)
+	ctx = ctx.WithContextID(context.ContextKeyTransactionID, txID)
+
+	txCRHeaders := utils.GetHeader(req.Header, apihttp.TransactionCreatedHeader)
+	ctx.Log().WithField(
+		apihttp.TransactionCreatedHeader, txCRHeaders).Debug("http header")
+
+	txCR := time.Now().UTC()
+	if len(txCRHeaders) > 0 {
+		epoch, err := strconv.ParseInt(txCRHeaders[0], 10, 64)
+		if err != nil {
+			return err
+		}
+		txCR = time.Unix(epoch, 0)
+	}
+	ctx = ctx.WithTransactionCreated(txCR)
+	ctx = ctx.WithContextID(
+		context.ContextKeyTransactionCreated,
+		fmt.Sprintf("%d", txCR.Unix()))
+
+	return h.handler(ctx, w, req, store)
+}

--- a/api/server/server_middleware.go
+++ b/api/server/server_middleware.go
@@ -17,7 +17,10 @@ func (s *server) initGlobalMiddleware() {
 			s.logHTTPResponses))
 	}
 
+	s.addGlobalMiddleware(handlers.NewTransactionHandler())
+
 	s.addGlobalMiddleware(handlers.NewErrorHandler())
+
 	s.addGlobalMiddleware(handlers.NewInstanceIDHandler())
 	s.addGlobalMiddleware(handlers.NewLocalDevicesHandler())
 }

--- a/api/types/http/http_headers.go
+++ b/api/types/http/http_headers.go
@@ -11,6 +11,14 @@ const (
 	// LocalDevicesHeader is the HTTP header that contains a local device pair.
 	LocalDevicesHeader = "libstorage-localdevices"
 
+	// TransactionIDHeader is the HTTP header that contains the transaction ID
+	// sent from the client.
+	TransactionIDHeader = "libstorage-txid"
+
+	// TransactionCreatedHeader is the HTTP header that contains the UTC
+	// epoch of the time that the transaction was created.
+	TransactionCreatedHeader = "libstorage-txcr"
+
 	// ServerNameHeader is the HTTP header that contains the randomly generated
 	// name the server creates for unique identification when the server starts
 	// for the first time. This header is provided with every response sent

--- a/api/types/types_context.go
+++ b/api/types/types_context.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 )
@@ -30,6 +32,10 @@ const (
 	ContextKeyLocalDevicesByService = "localDevicesByService"
 	// ContextKeyServerName is a context key.
 	ContextKeyServerName = "serverName"
+	// ContextKeyTransactionID is a context key.
+	ContextKeyTransactionID = "txID"
+	// ContextKeyTransactionCreated is a context key.
+	ContextKeyTransactionCreated = "txCR"
 )
 
 // Context is a libStorage context.
@@ -38,6 +44,13 @@ type Context interface {
 
 	// ServerName gets the server name.
 	ServerName() string
+
+	// TransactionID gets the transaction ID.
+	TransactionID() string
+
+	// TransactionCreated gets the timestamp of when the transaction was
+	// created.
+	TransactionCreated() time.Time
 
 	// InstanceIDsByService returns the context's service to instance ID map.
 	InstanceIDsByService() map[string]*InstanceID
@@ -84,6 +97,13 @@ type Context interface {
 	// The context ID is often used with logging to identify a log statement's
 	// origin.
 	WithContextID(id, value string) Context
+
+	// WithTransactionID returns a context with the provided transaction ID.
+	WithTransactionID(transactionID string) Context
+
+	// WithTransactionCreated returns a context with the provided transaction
+	// created timestamp.
+	WithTransactionCreated(timestamp time.Time) Context
 
 	// WithValue returns a context with the provided value.
 	WithValue(key interface{}, val interface{}) Context

--- a/client/client_init.go
+++ b/client/client_init.go
@@ -175,8 +175,9 @@ func getHost(proto, lAddr string, tlsConfig *tls.Config) string {
 }
 
 func (c *lsc) updateServiceInfo() error {
-	c.ctx.Log().Debug("getting service information")
-	svcInfo, err := c.Client.Services(c.ctx)
+	ctx := c.getTXCTX()
+	ctx.Log().Debug("getting service information")
+	svcInfo, err := c.Client.Services(ctx)
 	if err != nil {
 		return err
 	}
@@ -195,8 +196,8 @@ func (c *lsc) updateInstanceIDs() error {
 		return nil
 	}
 
-	c.ctx.Log().Debug("getting instance IDs")
-
+	ctx := c.getTXCTX()
+	ctx.Log().Debug("getting instance IDs")
 	cache := map[string]*iidHeader{}
 
 	for service, si := range c.svcInfo {
@@ -205,7 +206,7 @@ func (c *lsc) updateInstanceIDs() error {
 			continue
 		}
 
-		iid, err := c.InstanceID(service)
+		iid, err := c.instanceID(ctx, service)
 		if err != nil {
 			return err
 		}
@@ -252,7 +253,8 @@ func (c *lsc) updateLocalDevices() error {
 		return nil
 	}
 
-	c.ctx.Log().Debug("getting local devices")
+	ctx := c.getTXCTX()
+	ctx.Log().Debug("getting local devices")
 
 	cache := map[string]*ldHeader{}
 
@@ -262,7 +264,7 @@ func (c *lsc) updateLocalDevices() error {
 			continue
 		}
 
-		ldm, err := c.LocalDevices(service)
+		ldm, err := c.localDevices(ctx, service)
 		if err != nil {
 			return err
 		}

--- a/libstorage.apib
+++ b/libstorage.apib
@@ -60,6 +60,19 @@ header in action:
 
         libStorage-LocalDevices: mock=/dev/xvda=/var/log, /dev/xvdb=/home, /dev/xvdc=/net/share, /dev/xvdd=/var/lib/backup
 
+### Transaction ID
+The transaction ID is a UUID/GUID that is used to track an operation
+from the time it originates on a client, through the server, and back
+to the client again. The header name is `libStorage-txID`:
+
+        libStorage-txID: 959716fa-6a76-4e48-6243-1dd328c0f313
+
+### Transaction Created
+The header `libStorage-txCR` is a UTC epoch timestamp that notes when
+the original client-side operation was created:
+
+        libStorage-txCR: 1461644872
+
 # Group Root
 
 # Root Resource [/]


### PR DESCRIPTION
This patch adds loose-transactions, the ability to track the provenance of an operation from the time it was generated on a client, through the server round-trip, and back into the client.

It does this via two HTTP headers, `libStorage-txID` and `libStorage-txCR`. The former is a UUID associated with every client->server->client round-trip and the latter is the UTC epoch that is the time at which the transaction was created.

```
$ LIBSTORAGE_DEBUG=true go test ./drivers/storage/mock/tests -run TestClient -v
=== RUN   TestClient
DEBU[0000] initializing server                           server=fierce-drop-pg
INFO[0000] configured endpoint                           address=tcp://127.0.0.1:29822 endpoint=localhost
INFO[0000] server created                                host=tcp://127.0.0.1:29822 server=fierce-drop-pg tls=false
DEBU[0000] initialized endpoints                         server=fierce-drop-pg
DEBU[0000] got services map                              count=3
DEBU[0000] processing service config                     service=mock2
DEBU[0000] getting scoped config for service             scope=libstorage.server.services.mock2
INFO[0000] created new service                           driver=mock service=mock2
DEBU[0000] processing service config                     service=mock3
DEBU[0000] getting scoped config for service             scope=libstorage.server.services.mock3
INFO[0000] created new service                           driver=mock service=mock3
DEBU[0000] processing service config                     service=mock
DEBU[0000] getting scoped config for service             scope=libstorage.server.services.mock
INFO[0000] created new service                           driver=mock service=mock
DEBU[0000] initialized services                          server=fierce-drop-pg
INFO[0000] initialized router                            len(routes)=3 router=executor-router
INFO[0000] initialized router                            len(routes)=1 router=root-router
INFO[0000] initialized router                            len(routes)=2 router=service-router
INFO[0000] initialized router                            len(routes)=6 router=snapshot-router
INFO[0000] initialized router                            len(routes)=2 router=tasks-router
INFO[0000] initialized router                            len(routes)=11 router=volume-router
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/executors queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/executors/{executor} queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=HEAD path=/executors/{executor} queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/ queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/services queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/services/{service} queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/snapshots queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/snapshots/{service} queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/snapshots/{service}/{snapshotID} queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=2 method=POST path=/snapshots/{service}/{snapshotID} queries=[create ] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=2 method=POST path=/snapshots/{service}/{snapshotID} queries=[copy ] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=DELETE path=/snapshots/{service}/{snapshotID} queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/tasks queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/tasks/{taskID} queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/volumes queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/volumes/{service} queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=GET path=/volumes/{service}/{volumeID} queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=2 method=POST path=/volumes/{service} queries=[detach ] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=POST path=/volumes/{service} queries=[] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=2 method=POST path=/volumes/{service}/{volumeID} queries=[copy ] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=2 method=POST path=/volumes/{service}/{volumeID} queries=[snapshot ] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=2 method=POST path=/volumes/{service}/{volumeID} queries=[attach ] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=2 method=POST path=/volumes queries=[detach ] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=2 method=POST path=/volumes/{service}/{volumeID} queries=[detach ] server=fierce-drop-pg tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:29822 len(queries)=0 method=DELETE path=/volumes/{service}/{volumeID} queries=[] server=fierce-drop-pg tls=false
DEBU[0000] waiting for err or close signal               server=fierce-drop-pg
INFO[0000] api listening                                 host=tcp://127.0.0.1:29822 server=fierce-drop-pg tls=false
INFO[0001] server started                                server=fierce-drop-pg
DEBU[0001] getting service information                   host=tcp://127.0.0.1:29822 txCR=1461644872 txID=959716fa-6a76-4e48-6243-1dd328c0f313
INFO[0001]
INFO[0001]     -------------------------- HTTP REQUEST (CLIENT) -------------------------
INFO[0001]     GET /services HTTP/1.1
INFO[0001]     Host: 127.0.0.1:29822
INFO[0001]     Libstorage-Txcr: 1461644872
INFO[0001]     Libstorage-Txid: 959716fa-6a76-4e48-6243-1dd328c0f313
INFO[0001]
DEBU[0001] http request                                  host=tcp://127.0.0.1:29822 route=services server=fierce-drop-pg tls=false
DEBU[0001] added route middleware                        host=tcp://127.0.0.1:29822 middleware=schema-validator route=services server=fierce-drop-pg tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:29822 middleware=local-devices-handler route=services server=fierce-drop-pg tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:29822 middleware=instanceIDs-handler route=services server=fierce-drop-pg tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:29822 middleware=error-handler route=services server=fierce-drop-pg tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:29822 middleware=transaction-handler route=services server=fierce-drop-pg tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:29822 middleware=logging-handler route=services server=fierce-drop-pg tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:29822 middleware=query-params-handler route=services server=fierce-drop-pg tls=false
DEBU[0001] http header                                   host=tcp://127.0.0.1:29822 libstorage-txid=[959716fa-6a76-4e48-6243-1dd328c0f313] route=services server=fierce-drop-pg tls=false
DEBU[0001] http header                                   host=tcp://127.0.0.1:29822 libstorage-txcr=[1461644872] route=services server=fierce-drop-pg tls=false txID=959716fa-6a76-4e48-6243-1dd328c0f313
DEBU[0001] http header                                   host=tcp://127.0.0.1:29822 libstorage-instanceid=[] route=services server=fierce-drop-pg tls=false txCR=1461644872 txID=959716fa-6a76-4e48-6243-1dd328c0f313
DEBU[0001] http header                                   host=tcp://127.0.0.1:29822 libstorage-instanceid64=[] route=services server=fierce-drop-pg tls=false txCR=1461644872 txID=959716fa-6a76-4e48-6243-1dd328c0f313
DEBU[0001] http header                                   host=tcp://127.0.0.1:29822 libstorage-localdevices=[] route=services server=fierce-drop-pg tls=false txCR=1461644872 txID=959716fa-6a76-4e48-6243-1dd328c0f313
INFO[0001] 127.0.0.1 - - [25/Apr/2016:23:27:52 -0500] "GET /services HTTP/1.1" 200 630
INFO[0001]
INFO[0001]     -------------------------- HTTP REQUEST (SERVER) --------------------------
INFO[0001]     GET /services HTTP/1.1
INFO[0001]     Host: 127.0.0.1:29822
INFO[0001]     Connection: close
INFO[0001]     Accept-Encoding: gzip
INFO[0001]     Connection: close
INFO[0001]     Libstorage-Txcr: 1461644872
INFO[0001]     Libstorage-Txid: 959716fa-6a76-4e48-6243-1dd328c0f313
INFO[0001]     User-Agent: Go-http-client/1.1
INFO[0001]
INFO[0001]     -------------------------- HTTP RESPONSE (SERVER) -------------------------
INFO[0001]     Content-Type=application/json
INFO[0001]
INFO[0001]     {
INFO[0001]       "mock": {
INFO[0001]         "name": "mock",
INFO[0001]         "driver": {
INFO[0001]           "name": "mock",
INFO[0001]           "type": "block",
INFO[0001]           "nextDevice": {
INFO[0001]             "ignore": true,
INFO[0001]             "prefix": "xvd",
INFO[0001]             "pattern": "\\w"
INFO[0001]           }
INFO[0001]         }
INFO[0001]       },
INFO[0001]       "mock2": {
INFO[0001]         "name": "mock2",
INFO[0001]         "driver": {
INFO[0001]           "name": "mock",
INFO[0001]           "type": "block",
INFO[0001]           "nextDevice": {
INFO[0001]             "ignore": true,
INFO[0001]             "prefix": "xvd",
INFO[0001]             "pattern": "\\w"
INFO[0001]           }
INFO[0001]         }
INFO[0001]       },
INFO[0001]       "mock3": {
INFO[0001]         "name": "mock3",
INFO[0001]         "driver": {
INFO[0001]           "name": "mock",
INFO[0001]           "type": "block",
INFO[0001]           "nextDevice": {
INFO[0001]             "ignore": true,
INFO[0001]             "prefix": "xvd",
INFO[0001]             "pattern": "\\w"
INFO[0001]           }
INFO[0001]         }
INFO[0001]       }
INFO[0001]     }
INFO[0001]
INFO[0001]     -------------------------- HTTP RESPONSE (CLIENT) -------------------------
INFO[0001]     HTTP/1.1 200 OK
INFO[0001]     Connection: close
INFO[0001]     Content-Length: 630
INFO[0001]     Content-Type: application/json
INFO[0001]     Date: Tue, 26 Apr 2016 04:27:52 GMT
INFO[0001]     Libstorage-Servername: fierce-drop-pg
INFO[0001]
INFO[0001]     {
INFO[0001]       "mock": {
INFO[0001]         "name": "mock",
INFO[0001]         "driver": {
INFO[0001]           "name": "mock",
INFO[0001]           "type": "block",
INFO[0001]           "nextDevice": {
INFO[0001]             "ignore": true,
INFO[0001]             "prefix": "xvd",
INFO[0001]             "pattern": "\\w"
INFO[0001]           }
INFO[0001]         }
INFO[0001]       },
INFO[0001]       "mock2": {
INFO[0001]         "name": "mock2",
INFO[0001]         "driver": {
INFO[0001]           "name": "mock",
INFO[0001]           "type": "block",
INFO[0001]           "nextDevice": {
INFO[0001]             "ignore": true,
INFO[0001]             "prefix": "xvd",
INFO[0001]             "pattern": "\\w"
INFO[0001]           }
INFO[0001]         }
INFO[0001]       },
INFO[0001]       "mock3": {
INFO[0001]         "name": "mock3",
INFO[0001]         "driver": {
INFO[0001]           "name": "mock",
INFO[0001]           "type": "block",
INFO[0001]           "nextDevice": {
INFO[0001]             "ignore": true,
INFO[0001]             "prefix": "xvd",
INFO[0001]             "pattern": "\\w"
INFO[0001]           }
INFO[0001]         }
INFO[0001]       }
INFO[0001]     }
DEBU[0001] getting executor information                  host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=440ca9e1-35b4-47ef-5a59-2ac05be21715
INFO[0001]
INFO[0001]     -------------------------- HTTP REQUEST (CLIENT) -------------------------
INFO[0001]     GET /executors HTTP/1.1
INFO[0001]     Host: 127.0.0.1:29822
INFO[0001]     Libstorage-Txcr: 1461644872
INFO[0001]     Libstorage-Txid: 440ca9e1-35b4-47ef-5a59-2ac05be21715
INFO[0001]
DEBU[0001] http request                                  host=tcp://127.0.0.1:29822 route=executors server=fierce-drop-pg tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:29822 middleware=local-devices-handler route=executors server=fierce-drop-pg tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:29822 middleware=instanceIDs-handler route=executors server=fierce-drop-pg tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:29822 middleware=error-handler route=executors server=fierce-drop-pg tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:29822 middleware=transaction-handler route=executors server=fierce-drop-pg tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:29822 middleware=logging-handler route=executors server=fierce-drop-pg tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:29822 middleware=query-params-handler route=executors server=fierce-drop-pg tls=false
DEBU[0001] http header                                   host=tcp://127.0.0.1:29822 libstorage-txid=[440ca9e1-35b4-47ef-5a59-2ac05be21715] route=executors server=fierce-drop-pg tls=false
DEBU[0001] http header                                   host=tcp://127.0.0.1:29822 libstorage-txcr=[1461644872] route=executors server=fierce-drop-pg tls=false txID=440ca9e1-35b4-47ef-5a59-2ac05be21715
DEBU[0001] http header                                   host=tcp://127.0.0.1:29822 libstorage-instanceid=[] route=executors server=fierce-drop-pg tls=false txCR=1461644872 txID=440ca9e1-35b4-47ef-5a59-2ac05be21715
DEBU[0001] http header                                   host=tcp://127.0.0.1:29822 libstorage-instanceid64=[] route=executors server=fierce-drop-pg tls=false txCR=1461644872 txID=440ca9e1-35b4-47ef-5a59-2ac05be21715
DEBU[0001] http header                                   host=tcp://127.0.0.1:29822 libstorage-localdevices=[] route=executors server=fierce-drop-pg tls=false txCR=1461644872 txID=440ca9e1-35b4-47ef-5a59-2ac05be21715
INFO[0001] 127.0.0.1 - - [25/Apr/2016:23:27:52 -0500] "GET /executors HTTP/1.1" 200 481
INFO[0001]
INFO[0001]     -------------------------- HTTP REQUEST (SERVER) --------------------------
INFO[0001]     GET /executors HTTP/1.1
INFO[0001]     Host: 127.0.0.1:29822
INFO[0001]     Connection: close
INFO[0001]     Accept-Encoding: gzip
INFO[0001]     Connection: close
INFO[0001]     Libstorage-Txcr: 1461644872
INFO[0001]     Libstorage-Txid: 440ca9e1-35b4-47ef-5a59-2ac05be21715
INFO[0001]     User-Agent: Go-http-client/1.1
INFO[0001]
INFO[0001]     -------------------------- HTTP RESPONSE (SERVER) -------------------------
INFO[0001]     Content-Type=application/json
INFO[0001]
INFO[0001]     {
INFO[0001]       "lsx-darwin": {
INFO[0001]         "name": "lsx-darwin",
INFO[0001]         "md5checksum": "a492678cb2b1387cd7ba2ef70f6d02e4",
INFO[0001]         "size": 11836532,
INFO[0001]         "lastModified": 1461626897
INFO[0001]       },
INFO[0001]       "lsx-linux": {
INFO[0001]         "name": "lsx-linux",
INFO[0001]         "md5checksum": "3c29d53fa18e00c830793357c80fefbc",
INFO[0001]         "size": 11866288,
INFO[0001]         "lastModified": 1461616949
INFO[0001]       },
INFO[0001]       "lsx-windows.exe": {
INFO[0001]         "name": "lsx-windows.exe",
INFO[0001]         "md5checksum": "bdeba40abf411e542d2e8737326bba15",
INFO[0001]         "size": 11757056,
INFO[0001]         "lastModified": 1461616949
INFO[0001]       }
INFO[0001]     }
INFO[0001]
INFO[0001]     -------------------------- HTTP RESPONSE (CLIENT) -------------------------
INFO[0001]     HTTP/1.1 200 OK
INFO[0001]     Connection: close
INFO[0001]     Content-Length: 481
INFO[0001]     Content-Type: application/json
INFO[0001]     Date: Tue, 26 Apr 2016 04:27:52 GMT
INFO[0001]     Libstorage-Servername: fierce-drop-pg
INFO[0001]
INFO[0001]     {
INFO[0001]       "lsx-darwin": {
INFO[0001]         "name": "lsx-darwin",
INFO[0001]         "md5checksum": "a492678cb2b1387cd7ba2ef70f6d02e4",
INFO[0001]         "size": 11836532,
INFO[0001]         "lastModified": 1461626897
INFO[0001]       },
INFO[0001]       "lsx-linux": {
INFO[0001]         "name": "lsx-linux",
INFO[0001]         "md5checksum": "3c29d53fa18e00c830793357c80fefbc",
INFO[0001]         "size": 11866288,
INFO[0001]         "lastModified": 1461616949
INFO[0001]       },
INFO[0001]       "lsx-windows.exe": {
INFO[0001]         "name": "lsx-windows.exe",
INFO[0001]         "md5checksum": "bdeba40abf411e542d2e8737326bba15",
INFO[0001]         "size": 11757056,
INFO[0001]         "lastModified": 1461616949
INFO[0001]       }
INFO[0001]     }
DEBU[0001] updating executor                             host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=99471dd1-a91d-4924-6c93-2c93137bcb4d
DEBU[0001] waiting on executor lock                      host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=99471dd1-a91d-4924-6c93-2c93137bcb4d
DEBU[0001] getting executor checksum                     host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=99471dd1-a91d-4924-6c93-2c93137bcb4d
DEBU[0001] signalling executor lock                      host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=99471dd1-a91d-4924-6c93-2c93137bcb4d
DEBU[0001] getting instance IDs                          host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=270b68a7-5098-42dc-6fca-e7a7b01a6ae1
DEBU[0001] waiting on executor lock                      host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=270b68a7-5098-42dc-6fca-e7a7b01a6ae1
DEBU[0001] signalling executor lock                      host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=270b68a7-5098-42dc-6fca-e7a7b01a6ae1
DEBU[0001] getting local devices                         host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=471dba59-41d6-4c5d-7fd5-f8b2572352ad
DEBU[0001] waiting on executor lock                      host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=471dba59-41d6-4c5d-7fd5-f8b2572352ad
DEBU[0001] signalling executor lock                      host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=471dba59-41d6-4c5d-7fd5-f8b2572352ad
DEBU[0001] created new libStorage client                 host=tcp://127.0.0.1:29822
DEBU[0001] waiting on executor lock                      host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=aa5e737f-ed93-4d8d-627b-d96bbae9444b
DEBU[0001] signalling executor lock                      host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=aa5e737f-ed93-4d8d-627b-d96bbae9444b
DEBU[0001] waiting on executor lock                      host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=d8e9a742-73fc-44e2-4e86-cc4fcc57d042
DEBU[0001] signalling executor lock                      host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=d8e9a742-73fc-44e2-4e86-cc4fcc57d042
DEBU[0001] waiting on executor lock                      host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=7b4af09d-da5d-4ab6-527d-f0b3845d50e3
DEBU[0001] signalling executor lock                      host=tcp://127.0.0.1:29822 server=fierce-drop-pg txCR=1461644872 txID=7b4af09d-da5d-4ab6-527d-f0b3845d50e3
INFO[0001] shutting down server                          server=fierce-drop-pg
INFO[0001] shutting down endpoint                        host=tcp://127.0.0.1:29822 server=fierce-drop-pg tls=false
DEBU[0001] shutdown endpoint complete                    host=tcp://127.0.0.1:29822 server=fierce-drop-pg tls=false
DEBU[0001] shutdown server complete                      server=fierce-drop-pg
DEBU[0001] received close signal                         server=fierce-drop-pg
DEBU[0001] closed server error channel                   server=fierce-drop-pg
--- PASS: TestClient (1.13s)
PASS
ok  	github.com/emccode/libstorage/drivers/storage/mock/tests	1.530s
