### PR TITLE
Semaphore Tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ api/server/executors/bin/
 c/libstor-s/libstor-s.so
 c/libstor-s/libstor-s.h
 c/libstor-s/libstor-s.a
+cli/semaphores/open
+cli/semaphores/wait
+cli/semaphores/signal
+cli/semaphores/unlink
 
 # Created by https://www.gitignore.io
 

--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,28 @@ GO_CLEAN += $(EXECUTORS_GENERATED)-clean
 $(API_SERVER_EXECUTORS_A): $(EXECUTORS_GENERATED)
 
 ################################################################################
+##                               SEMAPHORE BINS                               ##
+################################################################################
+SEM_OPEN := ./cli/semaphores/open
+SEM_WAIT := ./cli/semaphores/wait
+SEM_SIGNAL := ./cli/semaphores/signal
+SEM_UNLINK := ./cli/semaphores/unlink
+
+$(SEM_OPEN): $(SEM_OPEN).c
+	gcc $? -o $@
+
+$(SEM_WAIT): $(SEM_WAIT).c
+	gcc $? -o $@
+
+$(SEM_SIGNAL): $(SEM_SIGNAL).c
+	gcc $? -o $@
+
+$(SEM_UNLINK): $(SEM_UNLINK).c
+	gcc $? -o $@
+
+sem-tools: $(SEM_OPEN) $(SEM_WAIT) $(SEM_SIGNAL) $(SEM_UNLINK)
+
+################################################################################
 ##                                  COVERAGE                                  ##
 ################################################################################
 COVERAGE := coverage.out
@@ -477,7 +499,7 @@ build-tests: $(GO_BUILD_TESTS)
 
 build-executors: $(EXECUTORS_EMBEDDED)
 
-build: $(GO_BUILD)
+build: sem-tools $(GO_BUILD)
 	$(MAKE) -j libstor-c libstor-s
 
 test: $(GO_TEST)

--- a/cli/semaphores/open.c
+++ b/cli/semaphores/open.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <semaphore.h>
+#include <errno.h>
+
+int main(int argc, char** argv) {
+	if (argc < 2) {
+		printf("open: %s <semaphore_name>\n", argv[0]);
+		return 1;
+	}
+	sem_t* sem = sem_open(argv[1], O_CREAT, 0644, 1);
+	if (sem == SEM_FAILED) {
+		return errno;
+	}
+	return 0;
+}

--- a/cli/semaphores/signal.c
+++ b/cli/semaphores/signal.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <semaphore.h>
+#include <errno.h>
+
+int main(int argc, char** argv) {
+	if (argc < 2) {
+		printf("signal: %s <semaphore_name>\n", argv[0]);
+		return 1;
+	}
+	sem_t* sem = sem_open(argv[1], O_CREAT, 0644, 1);
+	if (sem == SEM_FAILED) {
+		return errno;
+	}
+	return sem_post(sem) ? errno : 0;
+}

--- a/cli/semaphores/unlink.c
+++ b/cli/semaphores/unlink.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <semaphore.h>
+#include <errno.h>
+#include <stdlib.h>
+
+int main(int argc, char** argv) {
+	if (argc < 2) {
+		printf("unlink: %s <semaphore_name>\n", argv[0]);
+		return 1;
+	}
+	return sem_unlink(argv[1]) ? errno : 0;
+}

--- a/cli/semaphores/wait.c
+++ b/cli/semaphores/wait.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <semaphore.h>
+#include <errno.h>
+
+int main(int argc, char** argv) {
+	if (argc < 2) {
+		printf("wait: %s <semaphore_name>\n", argv[0]);
+		return 1;
+	}
+	sem_t* sem = sem_open(argv[1], O_CREAT, 0644, 1);
+	if (sem == SEM_FAILED) {
+		return errno;
+	}
+	return sem_wait(sem) ? errno : 0;
+}


### PR DESCRIPTION
This patch adds some tools to help manage semaphores during development. The tools are compiled to `./cli/semaphores`:

* `open`    - opens a named semaphore with an initial value of 1
* `wait`    - blocks until the named semaphore has a value > 0
* `signal`  - increments the named semaphore's value by 1
* `unlink`  - unlinks the named semaphore

Related to issue #48.

To prove the tools, do the following:

## Terminal Session 1
Open a terminal session.

### Unlink the semaphore
This ensures the semaphore doesn't exist.
```
$ ./cli/semaphores/unlink /lsx-darwin
```

### Open the semaphore
This will created a named semaphore, `/lsx-darwin`, with an initial value of `1`.
```
$ ./cli/semaphores/open /lsx-darwin
```

### Wait on the semaphore
This will return immediately since the initial value is `1`.
```
$ ./cli/semaphores/wait /lsx-darwin
```

### Wait on the semaphore (again)
This will block since the semaphore has a zero value.
```
$ ./cli/semaphores/wait /lsx-darwin
```

## Terminal Session 2
Open a second terminal session.

### Signal the semaphore
This will increment the value of the semaphore by `1`, unblocking the `wait` command in the first terminal session.
```
$ ./cli/semaphores/signal /lsx-darwin
```

## Terminal Session 1
Verify the command is no longer being blocked and unlink the semaphore for future use.
```
$ ./cli/semaphores/unlink /lsx-darwin
```