### PR TITLE
Travis Caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ install:
 script:
   - make glide.lock
   - make -j cover
+cache:
+  directories:
+  - vendor


### PR DESCRIPTION
This patch introduces Travis caching, as well as admitting the Glide lock file into the repository. Since the Makefile always rebuilds the lock file if glide.yaml changes, this will speed up builds without causing stale dependencies.