### PR TITLE
Instance Inspection

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -41,6 +41,12 @@ type APIClient interface {
 	// Root returns a list of root resources.
 	Root(ctx types.Context) ([]string, error)
 
+	// Instances returns a list of instances.
+	Instances(ctx types.Context) ([]*types.Instance, error)
+
+	// InstanceInspect inspects an instance.
+	InstanceInspect(ctx types.Context, service string) (*types.Instance, error)
+
 	// Services returns a map of the configured Services.
 	Services(ctx types.Context) (map[string]*types.ServiceInfo, error)
 

--- a/api/server/services/services.go
+++ b/api/server/services/services.go
@@ -100,9 +100,6 @@ func (sc *serviceContainer) initStorageServices(ctx types.Context) error {
 			"configKey": types.ConfigServices,
 			"obj":       cfgSvcs,
 		}, "invalid format")
-		err.IncludeFieldsInString(true)
-		err.IncludeFieldsInError(true)
-		err.IncludeFieldsInFormat(true)
 		return err
 	}
 	ctx.WithField("count", len(cfgSvcsMap)).Debug("got services map")

--- a/api/tests/tests.go
+++ b/api/tests/tests.go
@@ -177,6 +177,13 @@ func (th *testHarness) run(
 		configNames, configs := getTestConfigs(t, driver, config)
 
 		for x, config := range configs {
+
+			cj, err := config.ToJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("client.config=%s\n", cj)
+
 			wg.Add(1)
 			go func(x int, config gofig.Config) {
 				defer wg.Done()

--- a/api/tests/tests_std.go
+++ b/api/tests/tests_std.go
@@ -7,7 +7,9 @@ import (
 	"github.com/akutz/gofig"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/emccode/libstorage/api/context"
 	"github.com/emccode/libstorage/api/types"
+	"github.com/emccode/libstorage/api/utils"
 	"github.com/emccode/libstorage/client"
 )
 
@@ -42,6 +44,38 @@ func (tt *InstanceIDTest) Test(
 	expectedJSON := string(expectedBuf)
 
 	iid, err := client.API().InstanceID(nil, tt.Driver)
+	assert.NoError(t, err)
+
+	iidBuf, err := json.Marshal(iid)
+	assert.NoError(t, err)
+	iidJSON := string(iidBuf)
+
+	assert.Equal(t, expectedJSON, iidJSON)
+}
+
+// InstanceTest is the test harness for testing instance inspection.
+type InstanceTest struct {
+
+	// Driver is the name of the driver/executor for which to inspect the
+	// instance.
+	Driver string
+
+	// Expected is the expected instance.
+	Expected *types.Instance
+}
+
+// Test is the APITestFunc for the InstanceTest.
+func (tt *InstanceTest) Test(
+	config gofig.Config,
+	client client.Client,
+	t *testing.T) {
+
+	expectedBuf, err := json.Marshal(tt.Expected)
+	assert.NoError(t, err)
+	expectedJSON := string(expectedBuf)
+
+	ctx := context.Background().WithServiceName(tt.Driver)
+	iid, err := client.Storage().InstanceInspect(ctx, utils.NewStore())
 	assert.NoError(t, err)
 
 	iidBuf, err := json.Marshal(iid)

--- a/api/types/types_context.go
+++ b/api/types/types_context.go
@@ -135,9 +135,8 @@ func (ck ContextKey) String() string {
 }
 
 const (
-
 	// ContextHTTPRequest is a context key.
-	ContextHTTPRequest ContextKey = iota
+	ContextHTTPRequest ContextKey = 5000 + iota
 
 	// ContextConfig is a context key.
 	ContextConfig

--- a/api/types/types_drivers_storage.go
+++ b/api/types/types_drivers_storage.go
@@ -85,11 +85,11 @@ type StorageDriver interface {
 	// NextDeviceInfo returns the information about the driver's next available
 	// device workflow.
 	NextDeviceInfo(
-		ctx Context) *NextDeviceInfo
+		ctx Context) (*NextDeviceInfo, error)
 
 	// Type returns the type of storage the driver provides.
 	Type(
-		ctx Context) StorageType
+		ctx Context) (StorageType, error)
 
 	// InstanceInspect returns an instance.
 	InstanceInspect(

--- a/api/types/types_model.go
+++ b/api/types/types_model.go
@@ -257,6 +257,9 @@ type ServiceInfo struct {
 	// Name is the service's name.
 	Name string `json:"name"`
 
+	// Instance is the service's instance.
+	Instance *Instance `json:"instance,omitempty"`
+
 	// Driver is the name of the driver registered for the service.
 	Driver *DriverInfo `json:"driver"`
 }

--- a/api/utils/schema/schema_generated.go
+++ b/api/utils/schema/schema_generated.go
@@ -207,6 +207,7 @@ const (
                     "type": "string",
                     "description": "Name is the service's name."
                 },
+                "instance": { "$ref": "#/definitions/instance" },
                 "driver": { "$ref": "#/definitions/driverInfo" }
             },
             "required": [ "name", "driver" ],

--- a/drivers/storage/libstorage/libstorage_client.go
+++ b/drivers/storage/libstorage/libstorage_client.go
@@ -105,14 +105,13 @@ func (c *client) NextDevice(
 	return gotil.Trim(string(out)), nil
 }
 
-func (c *client) NextDeviceInfo(ctx types.Context) *types.NextDeviceInfo {
-	// TODO libstorage StorageDriver .NextDeviceInfo
-	return nil
+func (c *client) Instances(ctx types.Context) ([]*types.Instance, error) {
+	return c.Client.Instances(c.withContext(ctx))
 }
 
-func (c *client) Type(ctx types.Context) types.StorageType {
-	// TODO libstorage StorageDriver .Type
-	return ""
+func (c *client) InstanceInspect(
+	ctx types.Context, service string) (*types.Instance, error) {
+	return c.Client.InstanceInspect(c.withContext(ctx), service)
 }
 
 func (c *client) Root(

--- a/drivers/storage/libstorage/libstorage_funcs.go
+++ b/drivers/storage/libstorage/libstorage_funcs.go
@@ -13,10 +13,31 @@ func (d *driver) API() lstypes.Client {
 	return &d.client
 }
 
+func (d *driver) NextDeviceInfo(
+	ctx types.Context) (*types.NextDeviceInfo, error) {
+
+	si, err := d.getServiceInfo(ctx.ServiceName())
+	if err != nil {
+		return nil, err
+	}
+
+	return si.Driver.NextDevice, nil
+}
+
+func (d *driver) Type(ctx types.Context) (types.StorageType, error) {
+
+	si, err := d.getServiceInfo(ctx.ServiceName())
+	if err != nil {
+		return "", err
+	}
+
+	return si.Driver.Type, nil
+}
+
 func (d *driver) InstanceInspect(
 	ctx types.Context,
 	opts types.Store) (*types.Instance, error) {
-	return nil, nil
+	return d.client.InstanceInspect(ctx, ctx.ServiceName())
 }
 
 func (d *driver) Volumes(

--- a/drivers/storage/mock/mock_driver.go
+++ b/drivers/storage/mock/mock_driver.go
@@ -88,19 +88,20 @@ func newDriver() types.StorageDriver {
 	return d
 }
 
-func (d *driver) Type(ctx types.Context) types.StorageType {
-	return types.Block
+func (d *driver) Type(ctx types.Context) (types.StorageType, error) {
+	return types.Block, nil
 }
 
-func (d *driver) NextDeviceInfo(ctx types.Context) *types.NextDeviceInfo {
-	return d.nextDeviceInfo
+func (d *driver) NextDeviceInfo(
+	ctx types.Context) (*types.NextDeviceInfo, error) {
+	return d.nextDeviceInfo, nil
 }
 
 func (d *driver) InstanceInspect(
 	ctx types.Context,
 	opts types.Store) (*types.Instance, error) {
 	iid, _ := d.InstanceID(ctx, opts)
-	return &types.Instance{InstanceID: iid}, nil
+	return &types.Instance{Name: "mockInstance", InstanceID: iid}, nil
 }
 
 func (d *driver) Volumes(

--- a/drivers/storage/mock/tests/mock_test.go
+++ b/drivers/storage/mock/tests/mock_test.go
@@ -80,11 +80,23 @@ func TestClient(t *testing.T) {
 }
 
 func TestInstanceID(t *testing.T) {
-	apitests.RunGroup(
+	apitests.Run(
 		t, mock.Name, nil,
 		(&apitests.InstanceIDTest{
 			Driver:   mock.Name,
 			Expected: mockx.GetInstanceID(),
+		}).Test)
+}
+
+func TestInstance(t *testing.T) {
+	apitests.Run(
+		t, mock.Name, nil,
+		(&apitests.InstanceTest{
+			Driver: mock.Name,
+			Expected: &types.Instance{
+				InstanceID: mockx.GetInstanceID(),
+				Name:       "mockInstance",
+			},
 		}).Test)
 }
 

--- a/drivers/storage/vfs/storage/vfs_storage.go
+++ b/drivers/storage/vfs/storage/vfs_storage.go
@@ -68,20 +68,24 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 	return nil
 }
 
-func (d *driver) Type(ctx types.Context) types.StorageType {
-	return types.Object
+func (d *driver) Type(ctx types.Context) (types.StorageType, error) {
+	return types.Object, nil
 }
 
-func (d *driver) NextDeviceInfo(ctx types.Context) *types.NextDeviceInfo {
+func (d *driver) NextDeviceInfo(
+	ctx types.Context) (*types.NextDeviceInfo, error) {
 	return &types.NextDeviceInfo{
 		Ignore: true,
-	}
+	}, nil
 }
 
 func (d *driver) InstanceInspect(
 	ctx types.Context,
 	opts types.Store) (*types.Instance, error) {
-	return &types.Instance{InstanceID: ctx.InstanceID()}, nil
+	return &types.Instance{
+		Name:       "vfsInstance",
+		InstanceID: ctx.InstanceID(),
+	}, nil
 }
 
 func (d *driver) Volumes(

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -474,11 +474,31 @@ func TestSnapshotRemove(t *testing.T) {
 func TestInstanceID(t *testing.T) {
 	iid, err := instanceID()
 	assert.NoError(t, err)
-	apitests.RunGroup(
+	if err != nil {
+		t.FailNow()
+	}
+	apitests.Run(
 		t, vfs.Name, newTestConfig(t),
 		(&apitests.InstanceIDTest{
 			Driver:   vfs.Name,
 			Expected: iid,
+		}).Test)
+}
+
+func TestInstance(t *testing.T) {
+	iid, err := instanceID()
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+	}
+	apitests.Run(
+		t, vfs.Name, nil,
+		(&apitests.InstanceTest{
+			Driver: vfs.Name,
+			Expected: &types.Instance{
+				InstanceID: iid,
+				Name:       "vfsInstance",
+			},
 		}).Test)
 }
 

--- a/libstorage.apib
+++ b/libstorage.apib
@@ -94,10 +94,18 @@ Gets a list of the API's top-level resources.
 
 # Group Services
 
-# Services Collection [/services]
+# Services Collection [/services?{instance}]
 
 ## Get [GET]
 Gets information about all of the configured services.
+
++ Parameters
+
+    + instance: `false` (boolean, optional)
+
+            When the instance query string is specified the instance ID header
+            is required. This flag indicates that the services' instances should
+            be retrieved along with standard service information.
 
 + Response 200 (application/json)
 
@@ -153,11 +161,16 @@ Internal server error
 
             { "$ref": "https://raw.githubusercontent.com/emccode/libstorage/master/libstorage.json#/definitions/internalServerError" }
 
-# Service Inspector [/services/{service}]
+# Service Inspector [/services/{service}?{instance}]
 
 + Parameters
 
     + service: `ec2-00` (string, required)
+    + instance: `false` (boolean, optional)
+
+            When the instance query string is specified the instance ID header
+            is required. This flag indicates that the service's instance should
+            be retrieved along with standard service information.
 
 ## Inspect [GET]
 Gets information about the service with the specified name.

--- a/libstorage.json
+++ b/libstorage.json
@@ -203,6 +203,7 @@
                     "type": "string",
                     "description": "Name is the service's name."
                 },
+                "instance": { "$ref": "#/definitions/instance" },
                 "driver": { "$ref": "#/definitions/driverInfo" }
             },
             "required": [ "name", "driver" ],


### PR DESCRIPTION
This patch completes the code to retrieve a service's instance as long as the instance ID is present and the query string `instance` is in the URL to retrieve one or more services.