### PR TITLE
Volume Filtering

### DIFF
--- a/api/types/types_errors.go
+++ b/api/types/types_errors.go
@@ -45,3 +45,7 @@ type ErrDriverTypeErr struct{ goof.Goof }
 // before the process is complete. This error will contain information about
 // the objects for which the process did complete.
 type ErrBatchProcess struct{ goof.Goof }
+
+// ErrBadFilter occurs when a bad filter is supplied via the filter query
+// string.
+type ErrBadFilter struct{ goof.Goof }

--- a/api/types/types_filter.go
+++ b/api/types/types_filter.go
@@ -1,0 +1,59 @@
+package types
+
+// FilterOperator is a filter operator.
+type FilterOperator int
+
+const (
+	// FilterAnd is the & operator.
+	FilterAnd FilterOperator = iota
+
+	// FilterOr is the | operator.
+	FilterOr
+
+	// FilterNot is the ! operator.
+	FilterNot
+
+	// FilterPresent is the =* operator.
+	FilterPresent
+
+	// FilterEqualityMatch is the = operator.
+	FilterEqualityMatch
+
+	// FilterSubstrings is the = operator in conjunction with a string that
+	// has leading and trailing * characters.
+	FilterSubstrings
+
+	// FilterSubstringsPrefix is the = operator in conjunction with a string
+	// that has a leading * character.
+	FilterSubstringsPrefix
+
+	// FilterSubstringsPostfix is the = operator in conjunction with a string
+	// that has a trailing * character.
+	FilterSubstringsPostfix
+
+	// FilterGreaterOrEqual is the >= operator.
+	FilterGreaterOrEqual
+
+	// FilterLessOrEqual is the <= operator.
+	FilterLessOrEqual
+
+	// FilterApproxMatch is the ~= operator.
+	FilterApproxMatch
+)
+
+// Filter is an LDAP-style filter string.
+type Filter struct {
+
+	// Op is the operation.
+	Op FilterOperator
+
+	// Children is a list of any sub-filters if this filter is a compound
+	// filter.
+	Children []*Filter
+
+	// Left is the left operand.
+	Left string
+
+	// Right is the right operand.
+	Right string
+}

--- a/api/utils/filters/filters.go
+++ b/api/utils/filters/filters.go
@@ -1,0 +1,201 @@
+/*
+Package filters is a piece of thievery as the LDAP filter parsing code was
+lifted serepticiously from
+https://github.com/tonnerre/go-ldap/blob/master/ldap.go. The code was reused
+this way as opposed to imports in order to modify it heavily for the needs of
+the project.
+*/
+package filters
+
+import (
+	"bytes"
+	"net/url"
+
+	"github.com/akutz/goof"
+
+	"github.com/emccode/libstorage/api/types"
+)
+
+const (
+	filterAnd               = types.FilterAnd
+	filterOr                = types.FilterOr
+	filterNot               = types.FilterNot
+	filterPresent           = types.FilterPresent
+	filterEqualityMatch     = types.FilterEqualityMatch
+	filterSubstrings        = types.FilterSubstrings
+	filterSubstringsPrefix  = types.FilterSubstringsPrefix
+	filterSubstringsPostfix = types.FilterSubstringsPostfix
+	filterGreaterOrEqual    = types.FilterGreaterOrEqual
+	filterLessOrEqual       = types.FilterLessOrEqual
+	filterApproxMatch       = types.FilterApproxMatch
+)
+
+var filterMap = map[types.FilterOperator]string{
+	filterAnd:            "And",
+	filterOr:             "Or",
+	filterNot:            "Not",
+	filterEqualityMatch:  "Equality Match",
+	filterSubstrings:     "Substrings",
+	filterGreaterOrEqual: "Greater Or Equal",
+	filterLessOrEqual:    "Less Or Equal",
+	filterPresent:        "Present",
+	filterApproxMatch:    "Approx Match",
+}
+
+var (
+	errCharZeroNotLParen = goof.New("filter does not start with an '()'")
+	errUnexpectedEOF     = goof.New("unexpected end of filter")
+	errCompile           = goof.New("error compiling filter")
+	errParse             = goof.New("error parsing filter")
+)
+
+// CompileFilter compiles a filter string.
+func CompileFilter(s string) (*types.Filter, error) {
+
+	es, err := url.QueryUnescape(s)
+	if err != nil {
+		return nil, err
+	}
+	s = es
+
+	if len(s) == 0 || s[0] != '(' {
+		return nil, errCharZeroNotLParen
+	}
+
+	f, pos, err := compileFilter(s, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	if pos != len(s) {
+		return nil, goof.WithField(
+			"extra", s[pos:],
+			"finished compiling filter with extra at end")
+	}
+
+	return f, nil
+}
+
+func compileFilterSet(
+	s string, pos int, parent *types.Filter) (int, error) {
+
+	for pos < len(s) && s[pos] == '(' {
+		child, newPos, err := compileFilter(s, pos+1)
+		if err != nil {
+			return pos, err
+		}
+		pos = newPos
+		parent.Children = append(parent.Children, child)
+	}
+
+	if pos == len(s) {
+		return pos, errUnexpectedEOF
+	}
+
+	return pos + 1, nil
+}
+
+func compileFilter(s string, pos int) (*types.Filter, int, error) {
+
+	switch s[pos] {
+	case '(':
+		f, newPos, err := compileFilter(s, pos+1)
+		newPos++
+		return f, newPos, err
+
+	case '&':
+		f := &types.Filter{Op: filterAnd}
+		newPos, err := compileFilterSet(s, pos+1, f)
+		return f, newPos, err
+
+	case '|':
+		f := &types.Filter{Op: filterOr}
+		newPos, err := compileFilterSet(s, pos+1, f)
+		return f, newPos, err
+
+	case '!':
+		f := &types.Filter{Op: filterNot}
+		child, newPos, err := compileFilter(s, pos+1)
+		f.Children = append(f.Children, child)
+		return f, newPos, err
+
+	default:
+
+		var (
+			f          *types.Filter
+			abuf, cbuf bytes.Buffer
+			newPos     = pos
+		)
+
+		for newPos < len(s) && s[newPos] != ')' {
+			switch {
+			case f != nil:
+				if err := cbuf.WriteByte(s[newPos]); err != nil {
+					return nil, 0, err
+				}
+
+			case s[newPos] == '=':
+				f = &types.Filter{Op: filterEqualityMatch}
+
+			case s[newPos] == '>' && s[newPos+1] == '=':
+				f = &types.Filter{Op: filterGreaterOrEqual}
+				newPos++
+
+			case s[newPos] == '<' && s[newPos+1] == '=':
+				f = &types.Filter{Op: filterLessOrEqual}
+				newPos++
+
+			case s[newPos] == '~' && s[newPos+1] == '=':
+				f = &types.Filter{Op: filterApproxMatch}
+				newPos++
+
+			case f == nil:
+				if err := abuf.WriteByte(s[newPos]); err != nil {
+					return nil, 0, err
+				}
+			}
+			newPos++
+		}
+
+		if newPos == len(s) {
+			return f, newPos, errUnexpectedEOF
+		}
+
+		if f == nil {
+			return nil, 0, errParse
+		}
+
+		f.Left = abuf.String()
+
+		var (
+			cbyt = cbuf.Bytes()
+			cstr = cbuf.String()
+			clen = len(cbyt)
+			cfch = cbyt[clen-1]
+		)
+
+		switch {
+		case f.Op == filterEqualityMatch && cstr == "*":
+			f.Op = filterPresent
+
+		case f.Op == filterEqualityMatch &&
+			cbyt[0] == '*' && cfch == '*' && clen > 2:
+			f.Op = filterSubstrings
+			f.Right = cstr[1 : clen-1]
+
+		case f.Op == filterEqualityMatch && cbyt[0] == '*' && clen > 1:
+			f.Op = filterSubstringsPrefix
+			f.Right = cstr[1:]
+
+		case f.Op == filterEqualityMatch && cfch == '*' && clen > 1:
+			f.Op = filterSubstringsPostfix
+			f.Right = cstr[:clen-1]
+
+		default:
+			f.Right = cstr
+
+		}
+		newPos++
+		return f, newPos, nil
+	}
+}

--- a/api/utils/filters/filters_test.go
+++ b/api/utils/filters/filters_test.go
@@ -1,0 +1,147 @@
+package filters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompilePresent(t *testing.T) {
+	f, err := CompileFilter(`(datacenter=*)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterPresent, f.Op)
+	assert.EqualValues(t, "datacenter", f.Left)
+}
+
+func TestCompileSubstring(t *testing.T) {
+	f, err := CompileFilter(`(datacenter=*Texas*)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterSubstrings, f.Op)
+	assert.EqualValues(t, "datacenter", f.Left)
+	assert.EqualValues(t, "Texas", f.Right)
+
+}
+
+func TestCompileSubstringPrefix(t *testing.T) {
+	f, err := CompileFilter(`(datacenter=*Texas)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterSubstringsPrefix, f.Op)
+	assert.EqualValues(t, "datacenter", f.Left)
+	assert.EqualValues(t, "Texas", f.Right)
+}
+
+func TestCompileSubstringPostfix(t *testing.T) {
+	f, err := CompileFilter(`(datacenter=Texas*)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterSubstringsPostfix, f.Op)
+	assert.EqualValues(t, "datacenter", f.Left)
+	assert.EqualValues(t, "Texas", f.Right)
+}
+
+func TestCompileAndEqualityFilter(t *testing.T) {
+	f, err := CompileFilter(`(&(datacenter=irvine)(department=finance))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterAnd, f.Op)
+
+	assert.EqualValues(t, filterEqualityMatch, f.Children[0].Op)
+	assert.EqualValues(t, "datacenter", f.Children[0].Left)
+	assert.EqualValues(t, "irvine", f.Children[0].Right)
+
+	assert.EqualValues(t, filterEqualityMatch, f.Children[1].Op)
+	assert.EqualValues(t, "department", f.Children[1].Left)
+	assert.EqualValues(t, "finance", f.Children[1].Right)
+}
+
+func TestCompileAndEqualityURLEscapedFilter(t *testing.T) {
+	f, err := CompileFilter(`(%26(datacenter=irvine)(department=finance))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterAnd, f.Op)
+
+	assert.EqualValues(t, filterEqualityMatch, f.Children[0].Op)
+	assert.EqualValues(t, "datacenter", f.Children[0].Left)
+	assert.EqualValues(t, "irvine", f.Children[0].Right)
+
+	assert.EqualValues(t, filterEqualityMatch, f.Children[1].Op)
+	assert.EqualValues(t, "department", f.Children[1].Left)
+	assert.EqualValues(t, "finance", f.Children[1].Right)
+}
+
+func TestCompileAndOrEqualityFilter(t *testing.T) {
+	f, err := CompileFilter(
+		`(&(|(datacenter=irvine)(datacenter=houston))(department=finance))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterAnd, f.Op)
+
+	assert.EqualValues(t, filterOr, f.Children[0].Op)
+
+	assert.EqualValues(t, filterEqualityMatch,
+		f.Children[0].Children[0].Op)
+	assert.EqualValues(t, "datacenter",
+		f.Children[0].Children[0].Left)
+	assert.EqualValues(t, "irvine",
+		f.Children[0].Children[0].Right)
+
+	assert.EqualValues(t, filterEqualityMatch,
+		f.Children[0].Children[1].Op)
+	assert.EqualValues(t, "datacenter",
+		f.Children[0].Children[1].Left)
+	assert.EqualValues(t, "houston",
+		f.Children[0].Children[1].Right)
+
+	assert.EqualValues(t, filterEqualityMatch, f.Children[1].Op)
+	assert.EqualValues(t, "department", f.Children[1].Left)
+	assert.EqualValues(t, "finance", f.Children[1].Right)
+}
+
+func TestCompileInequalityMatch(t *testing.T) {
+	f, err := CompileFilter(
+		`(&(|(datacenter=irvine)(!(datacenter=houston)))(department=finance))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, filterAnd, f.Op)
+
+	assert.EqualValues(t, filterOr, f.Children[0].Op)
+
+	assert.EqualValues(t, filterEqualityMatch,
+		f.Children[0].Children[0].Op)
+	assert.EqualValues(t, "datacenter",
+		f.Children[0].Children[0].Left)
+	assert.EqualValues(t, "irvine",
+		f.Children[0].Children[0].Right)
+
+	assert.EqualValues(t, filterNot, f.Children[0].Children[1].Op)
+
+	assert.EqualValues(t, filterEqualityMatch,
+		f.Children[0].Children[1].Children[0].Op)
+	assert.EqualValues(t, "datacenter",
+		f.Children[0].Children[1].Children[0].Left)
+	assert.EqualValues(t, "houston",
+		f.Children[0].Children[1].Children[0].Right)
+
+	assert.EqualValues(t, filterEqualityMatch, f.Children[1].Op)
+	assert.EqualValues(t, "department", f.Children[1].Left)
+	assert.EqualValues(t, "finance", f.Children[1].Right)
+}

--- a/api/utils/utils_errors.go
+++ b/api/utils/utils_errors.go
@@ -64,3 +64,9 @@ func NewBatchProcessErr(completed interface{}, err error) error {
 	return &types.ErrBatchProcess{Goof: goof.WithFieldE(
 		"completed", completed, "batch processing error", err)}
 }
+
+// NewBadFilterErr returns a new ErrBadFilter error.
+func NewBadFilterErr(filter string, err error) error {
+	return &types.ErrBadFilter{Goof: goof.WithFieldE(
+		"filter", filter, "bad filter", err)}
+}


### PR DESCRIPTION
This patch provides the ability to filter volumes from `/volumes` or `/volumes/{service}` with an LDAP filter appended as a query string `?filter=(name%3D{name})`. Currently `name` is the only supported search token.

It's also possible to query a single volume by name with `/volumes/{service}/{volumeID}?byName`. The presence of the `byName` query string indicates to the server to consider the volume ID to be instead the volume name.