### PR TITLE
Fix for Driver Manager Contexts

### DIFF
--- a/api/registry/registry_integration.go
+++ b/api/registry/registry_integration.go
@@ -40,7 +40,7 @@ func (d *idm) List(
 	ctx types.Context,
 	opts types.Store) ([]types.VolumeMapping, error) {
 
-	volMaps, err := d.IntegrationDriver.List(ctx, opts)
+	volMaps, err := d.IntegrationDriver.List(ctx.Join(d.Context), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (d *idm) Inspect(
 	ctx types.Context,
 	volumeName string,
 	opts types.Store) (types.VolumeMapping, error) {
-	return d.IntegrationDriver.Inspect(ctx, volumeName, opts)
+	return d.IntegrationDriver.Inspect(ctx.Join(d.Context), volumeName, opts)
 }
 
 func (d *idm) Mount(
@@ -78,7 +78,8 @@ func (d *idm) Mount(
 	volumeID, volumeName string,
 	opts *types.VolumeMountOpts) (string, *types.Volume, error) {
 
-	mp, vol, err := d.IntegrationDriver.Mount(ctx, volumeID, volumeName, opts)
+	mp, vol, err := d.IntegrationDriver.Mount(
+		ctx.Join(d.Context), volumeID, volumeName, opts)
 	if err != nil {
 		return "", nil, err
 	}
@@ -96,7 +97,8 @@ func (d *idm) Unmount(
 		!d.isCounted(volumeName) {
 
 		d.initCount(volumeName)
-		return d.IntegrationDriver.Unmount(ctx, volumeID, volumeName, opts)
+		return d.IntegrationDriver.Unmount(
+			ctx.Join(d.Context), volumeID, volumeName, opts)
 	}
 
 	d.decCount(volumeName)
@@ -114,7 +116,8 @@ func (d *idm) Path(
 		"volumeID":   volumeID}
 
 	if !d.pathCache() {
-		return d.IntegrationDriver.Path(ctx, volumeID, volumeName, opts)
+		return d.IntegrationDriver.Path(
+			ctx.Join(d.Context), volumeID, volumeName, opts)
 	}
 
 	if !d.isCounted(volumeName) {
@@ -132,7 +135,7 @@ func (d *idm) Create(
 	if d.disableCreate() {
 		return nil, nil
 	}
-	return d.IntegrationDriver.Create(ctx, volumeName, opts)
+	return d.IntegrationDriver.Create(ctx.Join(d.Context), volumeName, opts)
 }
 
 func (d *idm) Remove(
@@ -142,28 +145,29 @@ func (d *idm) Remove(
 	if d.disableRemove() {
 		return nil
 	}
-	return d.IntegrationDriver.Remove(ctx, volumeName, opts)
+	return d.IntegrationDriver.Remove(ctx.Join(d.Context), volumeName, opts)
 }
 
 func (d *idm) Attach(
 	ctx types.Context,
 	volumeName string,
 	opts *types.VolumeAttachOpts) (string, error) {
-	return d.IntegrationDriver.Attach(ctx, volumeName, opts)
+	return d.IntegrationDriver.Attach(ctx.Join(d.Context), volumeName, opts)
 }
 
 func (d *idm) Detach(
 	ctx types.Context,
 	volumeName string,
 	opts *types.VolumeDetachOpts) error {
-	return d.IntegrationDriver.Detach(ctx, volumeName, opts)
+	return d.IntegrationDriver.Detach(ctx.Join(d.Context), volumeName, opts)
 }
 
 func (d *idm) NetworkName(
 	ctx types.Context,
 	volumeName string,
 	opts types.Store) (string, error) {
-	return d.IntegrationDriver.NetworkName(ctx, volumeName, opts)
+	return d.IntegrationDriver.NetworkName(
+		ctx.Join(d.Context), volumeName, opts)
 }
 
 func (d *idm) initCount(volumeName string) {

--- a/api/registry/registry_os.go
+++ b/api/registry/registry_os.go
@@ -17,10 +17,47 @@ func NewOSDriverManager(
 	return &odm{OSDriver: d}
 }
 
+func (d *odm) Mounts(
+	ctx types.Context,
+	deviceName, mountPoint string,
+	opts types.Store) ([]*types.MountInfo, error) {
+	ctx = ctx.Join(d.Context)
+
+	return d.OSDriver.Mounts(ctx.Join(d.Context), deviceName, mountPoint, opts)
+}
+
+func (d *odm) Mount(
+	ctx types.Context,
+	deviceName, mountPoint string,
+	opts *types.DeviceMountOpts) error {
+	ctx = ctx.Join(d.Context)
+
+	return d.OSDriver.Mount(ctx.Join(d.Context), deviceName, mountPoint, opts)
+}
+
+func (d *odm) Unmount(
+	ctx types.Context,
+	mountPoint string,
+	opts types.Store) error {
+
+	return d.OSDriver.Unmount(ctx.Join(d.Context), mountPoint, opts)
+}
+
+func (d *odm) IsMounted(
+	ctx types.Context,
+	mountPoint string,
+	opts types.Store) (bool, error) {
+
+	return d.OSDriver.IsMounted(ctx.Join(d.Context), mountPoint, opts)
+}
+
 func (d *odm) Format(
 	ctx types.Context,
 	deviceName string,
 	opts *types.DeviceFormatOpts) error {
+
+	ctx = ctx.Join(d.Context)
+
 	if strings.Contains(deviceName, ":") {
 		return nil
 	}

--- a/api/registry/registry_storage.go
+++ b/api/registry/registry_storage.go
@@ -22,3 +22,137 @@ func (d *sdm) API() lstypes.Client {
 	}
 	return nil
 }
+
+func (d *sdm) NextDeviceInfo(
+	ctx types.Context) (*types.NextDeviceInfo, error) {
+
+	return d.StorageDriver.NextDeviceInfo(ctx.Join(d.Context))
+}
+
+func (d *sdm) Type(
+	ctx types.Context) (types.StorageType, error) {
+
+	return d.StorageDriver.Type(ctx.Join(d.Context))
+}
+
+func (d *sdm) InstanceInspect(
+	ctx types.Context,
+	opts types.Store) (*types.Instance, error) {
+
+	return d.StorageDriver.InstanceInspect(ctx.Join(d.Context), opts)
+}
+
+func (d *sdm) Volumes(
+	ctx types.Context,
+	opts *types.VolumesOpts) ([]*types.Volume, error) {
+
+	return d.StorageDriver.Volumes(ctx.Join(d.Context), opts)
+}
+
+func (d *sdm) VolumeInspect(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeInspectOpts) (*types.Volume, error) {
+
+	return d.StorageDriver.VolumeInspect(ctx.Join(d.Context), volumeID, opts)
+}
+
+func (d *sdm) VolumeCreate(
+	ctx types.Context,
+	name string,
+	opts *types.VolumeCreateOpts) (*types.Volume, error) {
+
+	return d.StorageDriver.VolumeCreate(ctx.Join(d.Context), name, opts)
+}
+
+func (d *sdm) VolumeCreateFromSnapshot(
+	ctx types.Context,
+	snapshotID,
+	volumeName string,
+	opts *types.VolumeCreateOpts) (*types.Volume, error) {
+
+	return d.StorageDriver.VolumeCreateFromSnapshot(
+		ctx.Join(d.Context), snapshotID, volumeName, opts)
+}
+
+func (d *sdm) VolumeCopy(
+	ctx types.Context,
+	volumeID,
+	volumeName string,
+	opts types.Store) (*types.Volume, error) {
+
+	return d.StorageDriver.VolumeCopy(
+		ctx.Join(d.Context), volumeID, volumeName, opts)
+}
+
+func (d *sdm) VolumeSnapshot(
+	ctx types.Context,
+	volumeID,
+	snapshotName string,
+	opts types.Store) (*types.Snapshot, error) {
+
+	return d.StorageDriver.VolumeSnapshot(
+		ctx.Join(d.Context), volumeID, snapshotName, opts)
+}
+
+func (d *sdm) VolumeRemove(
+	ctx types.Context,
+	volumeID string,
+	opts types.Store) error {
+
+	return d.StorageDriver.VolumeRemove(
+		ctx.Join(d.Context), volumeID, opts)
+}
+
+func (d *sdm) VolumeAttach(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeAttachOpts) (*types.Volume, error) {
+
+	return d.StorageDriver.VolumeAttach(
+		ctx.Join(d.Context), volumeID, opts)
+}
+
+func (d *sdm) VolumeDetach(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeDetachOpts) (*types.Volume, error) {
+
+	return d.StorageDriver.VolumeDetach(
+		ctx.Join(d.Context), volumeID, opts)
+}
+
+func (d *sdm) Snapshots(
+	ctx types.Context,
+	opts types.Store) ([]*types.Snapshot, error) {
+
+	return d.StorageDriver.Snapshots(ctx.Join(d.Context), opts)
+}
+
+func (d *sdm) SnapshotInspect(
+	ctx types.Context,
+	snapshotID string,
+	opts types.Store) (*types.Snapshot, error) {
+
+	return d.StorageDriver.SnapshotInspect(
+		ctx.Join(d.Context), snapshotID, opts)
+}
+
+func (d *sdm) SnapshotCopy(
+	ctx types.Context,
+	snapshotID,
+	snapshotName,
+	destinationID string,
+	opts types.Store) (*types.Snapshot, error) {
+
+	return d.StorageDriver.SnapshotCopy(
+		ctx.Join(d.Context), snapshotID, snapshotName, destinationID, opts)
+}
+
+func (d *sdm) SnapshotRemove(
+	ctx types.Context,
+	snapshotID string,
+	opts types.Store) error {
+
+	return d.StorageDriver.SnapshotRemove(ctx.Join(d.Context), snapshotID, opts)
+}


### PR DESCRIPTION
This patch fixes a bug where the driver managers were not joining a call-scoped context with the driver manager's persistent context. This resulted in the contexts' drivers being nil by the time they reached the consumers. (cc @clintonskitson)