### PR TITLE
Auto Start Server

### DIFF
--- a/api/tests/tests.go
+++ b/api/tests/tests.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strconv"
@@ -21,6 +20,7 @@ import (
 
 	apiserver "github.com/emccode/libstorage/api/server"
 	"github.com/emccode/libstorage/api/server/executors"
+	"github.com/emccode/libstorage/api/utils"
 	"github.com/emccode/libstorage/client"
 )
 
@@ -357,8 +357,8 @@ func (th *testHarness) closeServers(t *testing.T) {
 func initTestConfigs(config map[string]interface{}) {
 	tcpHost := fmt.Sprintf("tcp://127.0.0.1:%d", gotil.RandomTCPPort())
 	tcpTLSHost := fmt.Sprintf("tcp://127.0.0.1:%d", gotil.RandomTCPPort())
-	unixHost := fmt.Sprintf("unix://%s", getTempSockFile())
-	unixTLSHost := fmt.Sprintf("unix://%s", getTempSockFile())
+	unixHost := fmt.Sprintf("unix://%s", utils.GetTempSockFile())
+	unixTLSHost := fmt.Sprintf("unix://%s", utils.GetTempSockFile())
 
 	clientTLSConfig := func() map[string]interface{} {
 		return map[string]interface{}{
@@ -441,16 +441,6 @@ func initTestConfigs(config map[string]interface{}) {
 			},
 		},
 	}
-}
-
-func getTempSockFile() string {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		panic(err)
-	}
-	name := f.Name()
-	os.RemoveAll(name)
-	return fmt.Sprintf("%s.sock", name)
 }
 
 // LogAsJSON logs the object as JSON using the test logger.

--- a/api/utils/utils.go
+++ b/api/utils/utils.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 
@@ -32,4 +34,15 @@ func GetHeader(headers http.Header, name string) []string {
 		}
 	}
 	return nil
+}
+
+// GetTempSockFile returns a new sock file in a temp space.
+func GetTempSockFile() string {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		panic(err)
+	}
+	name := f.Name()
+	os.RemoveAll(name)
+	return fmt.Sprintf("%s.sock", name)
 }


### PR DESCRIPTION
This patch introduces a new, root level function named New. It can be used to get a libStorage client, and additionally, if the provided configuration instance does not contain host information, a new, embedded host will be launched based on service information in the provided configuration.