### PR TITLE
Local Device Nil Header Fix

### DIFF
--- a/api/server/handlers/handlers_local_devices.go
+++ b/api/server/handlers/handlers_local_devices.go
@@ -49,6 +49,10 @@ func (h *localDevicesHandler) Handle(
 	for _, v := range headers {
 
 		locDevM := locDevRX.FindStringSubmatch(v)
+		if len(locDevM) == 0 {
+			continue
+		}
+
 		driver := locDevM[1]
 
 		devMntPairs := strings.Split(locDevM[2], ",")


### PR DESCRIPTION
This patch fixes a panic attack when the local device header is specified but does not match the required pattern.