### PR TITLE
Volume Attach Token

### DIFF
--- a/api/client/client_api_funcs.go
+++ b/api/client/client_api_funcs.go
@@ -191,15 +191,15 @@ func (c *client) VolumeAttach(
 	ctx types.Context,
 	service string,
 	volumeID string,
-	request *types.VolumeAttachRequest) (*types.Volume, error) {
+	request *types.VolumeAttachRequest) (*types.Volume, string, error) {
 	cctx(&ctx)
-	reply := types.Volume{}
+	reply := types.VolumeAttachResponse{}
 	if _, err := c.httpPost(ctx,
 		fmt.Sprintf("/volumes/%s/%s?attach",
 			service, volumeID), request, &reply); err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return &reply, nil
+	return reply.Volume, reply.AttachToken, nil
 }
 
 // VolumeDetach attaches a single volume.

--- a/api/registry/registry_storage.go
+++ b/api/registry/registry_storage.go
@@ -113,7 +113,7 @@ func (d *sdm) VolumeRemove(
 func (d *sdm) VolumeAttach(
 	ctx types.Context,
 	volumeID string,
-	opts *types.VolumeAttachOpts) (*types.Volume, error) {
+	opts *types.VolumeAttachOpts) (*types.Volume, string, error) {
 
 	return d.StorageDriver.VolumeAttach(
 		ctx.Join(d.Context), volumeID, opts)

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -438,7 +438,7 @@ func (r *router) volumeAttach(
 		ctx types.Context,
 		svc types.StorageService) (interface{}, error) {
 
-		v, err := svc.Driver().VolumeAttach(
+		v, attTokn, err := svc.Driver().VolumeAttach(
 			ctx,
 			store.GetString("volumeID"),
 			&types.VolumeAttachOpts{
@@ -461,14 +461,17 @@ func (r *router) volumeAttach(
 			}
 		}
 
-		return v, nil
+		return &types.VolumeAttachResponse{
+			Volume:      v,
+			AttachToken: attTokn,
+		}, nil
 	}
 
 	return httputils.WriteTask(
 		ctx,
 		w,
 		store,
-		service.TaskExecute(ctx, run, schema.VolumeSchema),
+		service.TaskExecute(ctx, run, schema.VolumeAttachResponseSchema),
 		http.StatusOK)
 }
 

--- a/api/tests/tests.go
+++ b/api/tests/tests.go
@@ -20,6 +20,7 @@ import (
 
 	apiserver "github.com/emccode/libstorage/api/server"
 	"github.com/emccode/libstorage/api/server/executors"
+	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/utils"
 	"github.com/emccode/libstorage/client"
 )
@@ -87,7 +88,7 @@ libstorage:
 //  2 - tcp+tls
 //  3 - sock
 //  4 - sock+tls
-type APITestFunc func(config gofig.Config, client client.Client, t *testing.T)
+type APITestFunc func(config gofig.Config, client types.Client, t *testing.T)
 
 // testHarness can be used by StorageDriver developers to quickly create
 // test suites for their drivers.

--- a/api/tests/tests_executors.go
+++ b/api/tests/tests_executors.go
@@ -8,13 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/emccode/libstorage/api/types"
-	"github.com/emccode/libstorage/client"
 )
 
 // TestExecutors tests the GET /executors route.
 var TestExecutors = func(
 	config gofig.Config,
-	client client.Client, t *testing.T) {
+	client types.Client, t *testing.T) {
 
 	reply, err := client.API().Executors(nil)
 	if err != nil {
@@ -28,7 +27,7 @@ var TestExecutors = func(
 // TestHeadExecutorWindows tests the HEAD /executors/lsx-windows.exe route.
 /*var TestHeadExecutorWindows = func(
 	config gofig.Config,
-	client client.Client, t *testing.T) {
+	client types.Client, t *testing.T) {
 
 	reply, err := client.API().ExecutorHead(nil, "lsx-windows.exe")
 	if err != nil {
@@ -40,7 +39,7 @@ var TestExecutors = func(
 // TestHeadExecutorLinux tests the HEAD /executors/lsx-linux route.
 var TestHeadExecutorLinux = func(
 	config gofig.Config,
-	client client.Client, t *testing.T) {
+	client types.Client, t *testing.T) {
 
 	reply, err := client.API().ExecutorHead(nil, "lsx-linux")
 	if err != nil {
@@ -52,7 +51,7 @@ var TestHeadExecutorLinux = func(
 // TestHeadExecutorDarwin tests the HEAD /executors/lsx-darwin route.
 var TestHeadExecutorDarwin = func(
 	config gofig.Config,
-	client client.Client, t *testing.T) {
+	client types.Client, t *testing.T) {
 
 	reply, err := client.API().ExecutorHead(nil, "lsx-darwin")
 	if err != nil {
@@ -64,7 +63,7 @@ var TestHeadExecutorDarwin = func(
 // TestGetExecutorWindows tests the GET /executors/lsx-windows.exe route.
 /*var TestGetExecutorWindows = func(
 	config gofig.Config,
-	client client.Client, t *testing.T) {
+	client types.Client, t *testing.T) {
 
 	reply, err := client.API().ExecutorGet(nil, "lsx-windows.exe")
 	if err != nil {
@@ -81,7 +80,7 @@ var TestHeadExecutorDarwin = func(
 // TestGetExecutorLinux tests the GET /executors/lsx-linux route.
 var TestGetExecutorLinux = func(
 	config gofig.Config,
-	client client.Client, t *testing.T) {
+	client types.Client, t *testing.T) {
 
 	reply, err := client.API().ExecutorGet(nil, "lsx-linux")
 	if err != nil {
@@ -98,7 +97,7 @@ var TestGetExecutorLinux = func(
 // TestGetExecutorDarwin tests the GET /executors/lsx-darwin route.
 var TestGetExecutorDarwin = func(
 	config gofig.Config,
-	client client.Client, t *testing.T) {
+	client types.Client, t *testing.T) {
 
 	reply, err := client.API().ExecutorGet(nil, "lsx-darwin")
 	if err != nil {

--- a/api/tests/tests_std.go
+++ b/api/tests/tests_std.go
@@ -10,11 +10,10 @@ import (
 	"github.com/emccode/libstorage/api/context"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/utils"
-	"github.com/emccode/libstorage/client"
 )
 
 // TestRoot tests the GET / route.
-var TestRoot = func(config gofig.Config, client client.Client, t *testing.T) {
+var TestRoot = func(config gofig.Config, client types.Client, t *testing.T) {
 	reply, err := client.API().Root(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +35,7 @@ type InstanceIDTest struct {
 // Test is the APITestFunc for the InstanceIDTest.
 func (tt *InstanceIDTest) Test(
 	config gofig.Config,
-	client client.Client,
+	client types.Client,
 	t *testing.T) {
 
 	expectedBuf, err := json.Marshal(tt.Expected)
@@ -68,7 +67,7 @@ type InstanceTest struct {
 // Test is the APITestFunc for the InstanceTest.
 func (tt *InstanceTest) Test(
 	config gofig.Config,
-	client client.Client,
+	client types.Client,
 	t *testing.T) {
 
 	tt.Expected.InstanceID.Formatted = true
@@ -101,7 +100,7 @@ type NextDeviceTest struct {
 // Test is the APITestFunc for the NextDeviceTest.
 func (tt *NextDeviceTest) Test(
 	config gofig.Config,
-	client client.Client,
+	client types.Client,
 	t *testing.T) {
 	val, err := client.Executor().NextDevice(
 		context.Background().WithServiceName(tt.Driver), utils.NewStore())
@@ -123,7 +122,7 @@ type LocalDevicesTest struct {
 // Test is the APITestFunc for the LocalDevicesTest.
 func (tt *LocalDevicesTest) Test(
 	config gofig.Config,
-	client client.Client,
+	client types.Client,
 	t *testing.T) {
 
 	expectedBuf, err := json.Marshal(tt.Expected)

--- a/api/types/types_clients.go
+++ b/api/types/types_clients.go
@@ -124,7 +124,7 @@ type APIClient interface {
 		ctx Context,
 		service string,
 		volumeID string,
-		request *VolumeAttachRequest) (*Volume, error)
+		request *VolumeAttachRequest) (*Volume, string, error)
 
 	// VolumeDetach attaches a single volume.
 	VolumeDetach(

--- a/api/types/types_drivers_executor.go
+++ b/api/types/types_drivers_executor.go
@@ -44,7 +44,7 @@ type ProvidesStorageExecutorCLI interface {
 type StorageExecutorCLI interface {
 	StorageExecutorFunctions
 
-	// WaitForDevice blocks until the provided volume ID appears in the
+	// WaitForDevice blocks until the provided attach token appears in the
 	// map returned from LocalDevices or until the timeout expires, whichever
 	// occurs first.
 	//
@@ -53,7 +53,7 @@ type StorageExecutorCLI interface {
 	// match is discovered or the timeout expires.
 	WaitForDevice(
 		ctx Context,
-		volumeID string,
+		attachToken string,
 		timeout time.Duration,
 		opts Store) (bool, map[string]string, error)
 }

--- a/api/types/types_drivers_storage.go
+++ b/api/types/types_drivers_storage.go
@@ -116,11 +116,12 @@ type StorageDriver interface {
 		volumeID string,
 		opts Store) error
 
-	// VolumeAttach attaches a volume.
+	// VolumeAttach attaches a volume and provides a token clients can use
+	// to validate that device has appeared locally.
 	VolumeAttach(
 		ctx Context,
 		volumeID string,
-		opts *VolumeAttachOpts) (*Volume, error)
+		opts *VolumeAttachOpts) (*Volume, string, error)
 
 	// VolumeDetach detaches a volume.
 	VolumeDetach(

--- a/api/types/types_http_responses.go
+++ b/api/types/types_http_responses.go
@@ -1,0 +1,8 @@
+package types
+
+// VolumeAttachResponse is the JSON response for attaching a volume to an
+// instance.
+type VolumeAttachResponse struct {
+	Volume      *Volume `json:"volume"`
+	AttachToken string  `json:"attachToken"`
+}

--- a/api/utils/schema/schema.go
+++ b/api/utils/schema/schema.go
@@ -71,6 +71,10 @@ var (
 	// request.
 	VolumeAttachRequestSchema = buildSchemaVar("volumeAttachRequest")
 
+	// VolumeAttachResponseSchema is the JSON schema for a Volume attach
+	// response.
+	VolumeAttachResponseSchema = buildSchemaVar("volumeAttachResponse")
+
 	// VolumeDetachRequestSchema is the JSON schema for a Volume detach
 	// request.
 	VolumeDetachRequestSchema = buildSchemaVar("volumeDetachRequest")

--- a/api/utils/schema/schema_generated.go
+++ b/api/utils/schema/schema_generated.go
@@ -459,6 +459,17 @@ const (
         },
 
 
+        "volumeAttachResponse": {
+            "type": "object",
+            "properties": {
+                "volume": { "$ref" : "#/definitions/volume" },
+                "attachToken" : { "type": "string" }
+            },
+            "required": [ "volume", "attachToken" ],
+            "additionalProperties": false
+        },
+
+
         "volumeDetachRequest": {
             "type": "object",
             "properties": {

--- a/c/libstor-c/libstor-c_exported.go
+++ b/c/libstor-c/libstor-c_exported.go
@@ -8,11 +8,11 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/emccode/libstorage/client"
+	"github.com/emccode/libstorage/api/types"
 )
 
 var (
-	clients    = map[C.h]client.Client{}
+	clients    = map[C.h]types.Client{}
 	clientsRWL = sync.RWMutex{}
 )
 

--- a/c/libstor-c/libstor-c_utils.go
+++ b/c/libstor-c/libstor-c_utils.go
@@ -87,7 +87,7 @@ func toCInstanceID(i *types.InstanceID) (*C.instance_id, error) {
 	}, nil
 }
 
-func newWithConfig(configPath string) (client.Client, error) {
+func newWithConfig(configPath string) (types.Client, error) {
 	config := gofig.New()
 	if err := config.ReadConfigFile(configPath); err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func newWithConfig(configPath string) (client.Client, error) {
 	return client.New(config)
 }
 
-func getClient(clientID C.h) (client.Client, error) {
+func getClient(clientID C.h) (types.Client, error) {
 	clientsRWL.RLock()
 	defer clientsRWL.RUnlock()
 	c, ok := clients[clientID]

--- a/cli/executors/executors.go
+++ b/cli/executors/executors.go
@@ -110,7 +110,7 @@ func Run() {
 			os.Exit(1)
 		}
 		op = "wait"
-		volID := args[3]
+		attachToken := args[3]
 		timeout, parseErr := time.ParseDuration(args[4])
 		if parseErr != nil {
 			err = parseErr
@@ -122,7 +122,7 @@ func Run() {
 					return false, nil, err
 				}
 				for k, _ := range ldm {
-					if strings.ToLower(k) == strings.ToLower(volID) {
+					if strings.ToLower(k) == strings.ToLower(attachToken) {
 						return true, ldm, nil
 					}
 				}
@@ -187,7 +187,7 @@ func Run() {
 
 func printUsage() {
 	buf := &bytes.Buffer{}
-	waitCmd := "wait {volumeID} {timeout}"
+	waitCmd := "wait {attachToken} {timeout}"
 	fmt.Fprintf(buf, "usage: %s {executor} ", os.Args[0])
 	lpad := fmt.Sprintf("%%%ds\n", buf.Len()+len(waitCmd))
 	fmt.Fprintf(buf, "instanceID|nextDevice|localDevices\n")

--- a/client/client.go
+++ b/client/client.go
@@ -11,25 +11,6 @@ import (
 	_ "github.com/emccode/libstorage/imports/local"
 )
 
-// Client is the libStorage client.
-type Client interface {
-
-	// API returns the underlying libStorage API client.
-	API() types.APIClient
-
-	// OS returns the client's OS driver instance.
-	OS() types.OSDriver
-
-	// Storage returns the client's storage driver instance.
-	Storage() types.StorageDriver
-
-	// IntegrationDriver returns the client's integration driver instance.
-	Integration() types.IntegrationDriver
-
-	// Executor returns the storage executor CLI.
-	Executor() types.StorageExecutorCLI
-}
-
 type client struct {
 	config gofig.Config
 	sd     types.StorageDriver
@@ -41,7 +22,7 @@ type client struct {
 }
 
 // New returns a new libStorage client.
-func New(config gofig.Config) (Client, error) {
+func New(config gofig.Config) (types.Client, error) {
 
 	var (
 		c   *client

--- a/drivers/integration/docker/docker.go
+++ b/drivers/integration/docker/docker.go
@@ -143,7 +143,7 @@ func (d *driver) Mount(
 		ctx.Debug("performing precautionary unmount")
 		_ = ctx.Client().OS().Unmount(ctx, mp, opts.Opts)
 
-		vol, err = ctx.Client().Storage().VolumeAttach(
+		vol, _, err = ctx.Client().Storage().VolumeAttach(
 			ctx, vol.ID, &types.VolumeAttachOpts{Force: opts.Preempt})
 		if err != nil {
 			return "", nil, err

--- a/drivers/storage/libstorage/libstorage_client_api.go
+++ b/drivers/storage/libstorage/libstorage_client_api.go
@@ -204,8 +204,9 @@ func (c *client) VolumeAttach(
 	ctx types.Context,
 	service string,
 	volumeID string,
-	request *types.VolumeAttachRequest) (*types.Volume, error) {
-	return c.APIClient.VolumeAttach(c.withContext(ctx), service, volumeID, request)
+	request *types.VolumeAttachRequest) (*types.Volume, string, error) {
+	return c.APIClient.VolumeAttach(
+		c.withContext(ctx), service, volumeID, request)
 }
 
 func (c *client) VolumeDetach(
@@ -213,7 +214,8 @@ func (c *client) VolumeDetach(
 	service string,
 	volumeID string,
 	request *types.VolumeDetachRequest) (*types.Volume, error) {
-	return c.APIClient.VolumeDetach(c.withContext(ctx), service, volumeID, request)
+	return c.APIClient.VolumeDetach(
+		c.withContext(ctx), service, volumeID, request)
 }
 
 func (c *client) VolumeDetachAll(
@@ -235,7 +237,8 @@ func (c *client) VolumeSnapshot(
 	service string,
 	volumeID string,
 	request *types.VolumeSnapshotRequest) (*types.Snapshot, error) {
-	return c.APIClient.VolumeSnapshot(c.withContext(ctx), service, volumeID, request)
+	return c.APIClient.VolumeSnapshot(
+		c.withContext(ctx), service, volumeID, request)
 }
 
 func (c *client) Snapshots(
@@ -264,7 +267,8 @@ func (c *client) SnapshotCopy(
 	ctx types.Context,
 	service, snapshotID string,
 	request *types.SnapshotCopyRequest) (*types.Snapshot, error) {
-	return c.APIClient.SnapshotCopy(c.withContext(ctx), service, snapshotID, request)
+	return c.APIClient.SnapshotCopy(
+		c.withContext(ctx), service, snapshotID, request)
 }
 
 func (c *client) Executors(

--- a/drivers/storage/libstorage/libstorage_client_xcli.go
+++ b/drivers/storage/libstorage/libstorage_client_xcli.go
@@ -115,7 +115,7 @@ func (c *client) NextDevice(
 
 func (c *client) WaitForDevice(
 	ctx types.Context,
-	volumeID string,
+	attachToken string,
 	timeout time.Duration,
 	opts types.Store) (bool, map[string]string, error) {
 
@@ -128,7 +128,8 @@ func (c *client) WaitForDevice(
 	driverName := si.Driver.Name
 
 	exitCode := 0
-	out, err := c.runExecutor(ctx, driverName, executors.WaitForDevice)
+	out, err := c.runExecutor(
+		ctx, driverName, executors.WaitForDevice, attachToken, timeout.String())
 	if exitError, ok := err.(*exec.ExitError); ok {
 		exitCode = exitError.Sys().(syscall.WaitStatus).ExitStatus()
 	}
@@ -159,7 +160,7 @@ func (c *client) WaitForDevice(
 }
 
 func (c *client) runExecutor(
-	ctx types.Context, driverName, cmdName string) ([]byte, error) {
+	ctx types.Context, args ...string) ([]byte, error) {
 
 	ctx.Debug("waiting on executor lock")
 	if err := lsxMutex.Wait(); err != nil {
@@ -173,7 +174,7 @@ func (c *client) runExecutor(
 		}
 	}()
 
-	cmd := exec.Command(c.lsxBinPath, driverName, cmdName)
+	cmd := exec.Command(c.lsxBinPath, args...)
 	cmd.Env = os.Environ()
 
 	ogLogLevel := c.config.GetLogLevel()

--- a/drivers/storage/libstorage/libstorage_driver_funcs.go
+++ b/drivers/storage/libstorage/libstorage_driver_funcs.go
@@ -156,7 +156,7 @@ func (d *driver) VolumeRemove(
 func (d *driver) VolumeAttach(
 	ctx types.Context,
 	volumeID string,
-	opts *types.VolumeAttachOpts) (*types.Volume, error) {
+	opts *types.VolumeAttachOpts) (*types.Volume, string, error) {
 
 	ctx = d.withContext(ctx)
 

--- a/drivers/storage/mock/mock_driver.go
+++ b/drivers/storage/mock/mock_driver.go
@@ -331,7 +331,7 @@ func (d *driver) VolumeRemove(
 func (d *driver) VolumeAttach(
 	ctx types.Context,
 	volumeID string,
-	opts *types.VolumeAttachOpts) (*types.Volume, error) {
+	opts *types.VolumeAttachOpts) (*types.Volume, string, error) {
 
 	var modVol *types.Volume
 	for _, vol := range d.volumes {
@@ -351,7 +351,7 @@ func (d *driver) VolumeAttach(
 		},
 	}
 
-	return modVol, nil
+	return modVol, "1234", nil
 }
 
 func (d *driver) VolumeDetach(

--- a/drivers/storage/mock/tests/mock_test.go
+++ b/drivers/storage/mock/tests/mock_test.go
@@ -14,7 +14,6 @@ import (
 	apitests "github.com/emccode/libstorage/api/tests"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/utils"
-	"github.com/emccode/libstorage/client"
 
 	// load the  driver
 
@@ -53,7 +52,7 @@ func TestMain(m *testing.M) {
 
 func TestStorageDriverVolumes(t *testing.T) {
 	apitests.Run(t, mock.Name, configYAML,
-		func(config gofig.Config, client client.Client, t *testing.T) {
+		func(config gofig.Config, client types.Client, t *testing.T) {
 			vols, err := client.Storage().Volumes(
 				context.WithServiceName(context.Background(), mock.Name),
 				&types.VolumesOpts{Attachments: true, Opts: utils.NewStore()})
@@ -64,7 +63,7 @@ func TestStorageDriverVolumes(t *testing.T) {
 
 func TestClient(t *testing.T) {
 	apitests.Run(t, mock.Name, configYAML,
-		func(config gofig.Config, client client.Client, t *testing.T) {
+		func(config gofig.Config, client types.Client, t *testing.T) {
 			iid, err := client.Executor().InstanceID(
 				context.Background().WithServiceName(mock.Name),
 				utils.NewStore())
@@ -115,7 +114,7 @@ func TestRoot(t *testing.T) {
 }
 
 func TestServices(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().Services(nil)
 		assert.NoError(t, err)
 		assert.Equal(t, len(reply), 3)
@@ -133,7 +132,7 @@ func TestServices(t *testing.T) {
 }
 
 func TestServiceInpspect(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().ServiceInspect(nil, "mock2")
 		assert.NoError(t, err)
 		assert.Equal(t, "mock2", reply.Name)
@@ -146,7 +145,7 @@ func TestServiceInpspect(t *testing.T) {
 }
 
 func TestSnapshotsByService(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().SnapshotsByService(nil, mock.Name)
 		assert.NoError(t, err)
 		apitests.LogAsJSON(reply, t)
@@ -158,7 +157,7 @@ func TestSnapshotsByService(t *testing.T) {
 }
 
 func TestVolumes(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().Volumes(nil, false)
 		assert.NoError(t, err)
 		apitests.LogAsJSON(reply, t)
@@ -173,7 +172,7 @@ func TestVolumes(t *testing.T) {
 }
 
 func TestVolumesWithAttachments(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().Volumes(nil, true)
 		assert.NoError(t, err)
 		apitests.LogAsJSON(reply, t)
@@ -191,7 +190,7 @@ func TestVolumesWithAttachments(t *testing.T) {
 }
 
 func TestVolumesWithAttachmentsNoLocalDevices(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		client.API().EnableLocalDevicesHeaders(false)
 		reply, err := client.API().Volumes(nil, true)
 		assert.NoError(t, err)
@@ -210,7 +209,7 @@ func TestVolumesWithAttachmentsNoLocalDevices(t *testing.T) {
 }
 
 func TestVolumesByService(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().VolumesByService(nil, mock.Name, false)
 		assert.NoError(t, err)
 		apitests.LogAsJSON(reply, t)
@@ -223,7 +222,7 @@ func TestVolumesByService(t *testing.T) {
 
 func TestVolumeCreate(t *testing.T) {
 
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		volumeName := "Volume 001"
 		availabilityZone := "US"
 		iops := int64(1000)
@@ -263,14 +262,14 @@ func TestVolumeCreate(t *testing.T) {
 
 func TestVolumeRemove(t *testing.T) {
 
-	tf1 := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf1 := func(config gofig.Config, client types.Client, t *testing.T) {
 		err := client.API().VolumeRemove(nil, mock.Name, "vol-000")
 		assert.NoError(t, err)
 	}
 
 	apitests.Run(t, mock.Name, configYAML, tf1, tf1)
 
-	tf2 := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf2 := func(config gofig.Config, client types.Client, t *testing.T) {
 		err := client.API().VolumeRemove(nil, mock.Name, "vol-000")
 		assert.Error(t, err)
 		assert.IsType(t, &types.JSONError{}, err)
@@ -284,7 +283,7 @@ func TestVolumeRemove(t *testing.T) {
 
 func TestVolumeSnapshot(t *testing.T) {
 
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		volumeID := "vol-000"
 		snapshotName := "snapshot1"
 		opts := map[string]interface{}{
@@ -309,7 +308,7 @@ func TestVolumeSnapshot(t *testing.T) {
 }
 
 func TestSnapshots(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().Snapshots(nil)
 		assert.NoError(t, err)
 		apitests.LogAsJSON(reply, t)
@@ -321,7 +320,7 @@ func TestSnapshots(t *testing.T) {
 }
 
 func TestSnapshotInspect(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().SnapshotInspect(nil, mock.Name, "snap-000")
 		assert.NoError(t, err)
 		assert.Equal(t, "Snapshot 0", reply.Name)
@@ -333,7 +332,7 @@ func TestSnapshotInspect(t *testing.T) {
 }
 
 func TestVolumeCreateFromSnapshot(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		volumeName := "Volume from snap-000"
 
 		availabilityZone := "US"
@@ -369,7 +368,7 @@ func TestVolumeCreateFromSnapshot(t *testing.T) {
 }
 
 func TestSnapshotRemove(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		assert.NoError(t, client.API().SnapshotRemove(
 			nil, mock.Name, "snap-000"))
 	}
@@ -377,7 +376,7 @@ func TestSnapshotRemove(t *testing.T) {
 }
 
 func TestSnapshotCopy(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		snapshotName := "Snapshot from snap-000"
 
 		opts := map[string]interface{}{
@@ -403,7 +402,7 @@ func TestSnapshotCopy(t *testing.T) {
 }
 
 func TestVolumeAttach(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 
 		opts := map[string]interface{}{
 			"priority": 2,
@@ -418,17 +417,19 @@ func TestVolumeAttach(t *testing.T) {
 			Opts:           opts,
 		}
 
-		reply, err := client.API().VolumeAttach(nil, mock.Name, "vol-001", request)
+		reply, attTokn, err := client.API().VolumeAttach(
+			nil, mock.Name, "vol-001", request)
 		assert.NoError(t, err)
-		apitests.LogAsJSON(reply, t)
+		assert.Equal(t, "1234", attTokn)
 		assert.Equal(
 			t, "vol-001", reply.ID)
 		assert.Equal(
 			t, "/dev/xvde", reply.Attachments[0].DeviceName)
 
-		reply, err = client.API().VolumeAttach(nil, mock.Name, "vol-002", request)
+		reply, attTokn, err = client.API().VolumeAttach(
+			nil, mock.Name, "vol-002", request)
 		assert.NoError(t, err)
-		apitests.LogAsJSON(reply, t)
+		assert.Equal(t, "1234", attTokn)
 		assert.Equal(
 			t, "vol-002", reply.ID)
 		assert.Equal(
@@ -439,7 +440,7 @@ func TestVolumeAttach(t *testing.T) {
 }
 
 func TestVolumeDetach(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		request := &types.VolumeDetachRequest{}
 		vol, err := client.API().VolumeDetach(nil, mock.Name, "vol-000", request)
 		assert.NoError(t, err)
@@ -450,7 +451,7 @@ func TestVolumeDetach(t *testing.T) {
 }
 
 func TestVolumeDetachAllForService(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 
 		opts := map[string]interface{}{
 			"priority": 2,
@@ -466,7 +467,7 @@ func TestVolumeDetachAllForService(t *testing.T) {
 			Opts:           opts,
 		}
 
-		_, err = client.API().VolumeAttach(nil, "mock2", "vol-000", request)
+		_, _, err = client.API().VolumeAttach(nil, "mock2", "vol-000", request)
 		assert.NoError(t, err)
 		var vol *types.Volume
 		vol, err = client.API().VolumeInspect(nil, "mock2", "vol-000", true)
@@ -484,7 +485,7 @@ func TestVolumeDetachAllForService(t *testing.T) {
 }
 
 func TestVolumeDetachAll(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 
 		opts := map[string]interface{}{
 			"priority": 2,

--- a/drivers/storage/vfs/storage/vfs_storage.go
+++ b/drivers/storage/vfs/storage/vfs_storage.go
@@ -291,11 +291,11 @@ func (d *driver) VolumeRemove(
 func (d *driver) VolumeAttach(
 	ctx types.Context,
 	volumeID string,
-	opts *types.VolumeAttachOpts) (*types.Volume, error) {
+	opts *types.VolumeAttachOpts) (*types.Volume, string, error) {
 
 	vol, err := d.getVolumeByID(volumeID)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	nextDevice := ""
@@ -312,12 +312,12 @@ func (d *driver) VolumeAttach(
 
 	vol.Attachments = append(vol.Attachments, att)
 	if err := d.writeVolume(vol); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	vol.Attachments = []*types.VolumeAttachment{att}
 
-	return vol, nil
+	return vol, "1234", nil
 }
 
 func (d *driver) VolumeDetach(

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -23,7 +23,6 @@ import (
 	apitests "github.com/emccode/libstorage/api/tests"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/utils"
-	"github.com/emccode/libstorage/client"
 
 	// load the vfs driver packages
 
@@ -41,7 +40,7 @@ func TestMain(m *testing.M) {
 
 func TestVolumes(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().Volumes(nil, false)
 		if err != nil {
 			t.Fatal(err)
@@ -56,7 +55,7 @@ func TestVolumes(t *testing.T) {
 
 func TestVolumesWithAttachments(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().Volumes(nil, true)
 		if err != nil {
 			t.Fatal(err)
@@ -73,7 +72,7 @@ func TestVolumesWithAttachments(t *testing.T) {
 
 func TestVolumesByService(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().VolumesByService(nil, "vfs", false)
 		if err != nil {
 			t.Fatal(err)
@@ -88,7 +87,7 @@ func TestVolumesByService(t *testing.T) {
 
 func TestVolumesByServiceWithAttachments(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().VolumesByService(nil, "vfs", true)
 		if err != nil {
 			t.Fatal(err)
@@ -104,7 +103,7 @@ func TestVolumesByServiceWithAttachments(t *testing.T) {
 
 func TestVolumeInspect(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().VolumeInspect(nil, "vfs", "vfs-000", false)
 		if err != nil {
 			t.Fatal(err)
@@ -117,7 +116,7 @@ func TestVolumeInspect(t *testing.T) {
 
 func TestVolumeInspectWithAttachments(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().VolumeInspect(nil, "vfs", "vfs-000", true)
 		if err != nil {
 			t.Fatal(err)
@@ -130,7 +129,7 @@ func TestVolumeInspectWithAttachments(t *testing.T) {
 
 func TestSnapshots(t *testing.T) {
 	tc, _, _, snaps := newTestConfigAll(t)
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().Snapshots(nil)
 		if err != nil {
 			t.Fatal(err)
@@ -145,7 +144,7 @@ func TestSnapshots(t *testing.T) {
 
 func TestSnapshotsByService(t *testing.T) {
 	tc, _, _, snaps := newTestConfigAll(t)
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().SnapshotsByService(nil, "vfs")
 		if err != nil {
 			t.Fatal(err)
@@ -159,7 +158,7 @@ func TestSnapshotsByService(t *testing.T) {
 }
 
 func TestVolumeCreate(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		volumeName := "Volume 003"
 		availabilityZone := "US"
 		iops := int64(1000)
@@ -201,7 +200,7 @@ func TestVolumeCreate(t *testing.T) {
 }
 
 func TestVolumeCopy(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		request := &types.VolumeCopyRequest{
 			VolumeName: "Copy of Volume 000",
 			Opts: map[string]interface{}{
@@ -230,7 +229,7 @@ func TestVolumeCopy(t *testing.T) {
 
 func TestVolumeRemove(t *testing.T) {
 
-	tf1 := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf1 := func(config gofig.Config, client types.Client, t *testing.T) {
 		assertVolDir(t, config, "vfs-002", true)
 		err := client.API().VolumeRemove(nil, vfs.Name, "vfs-002")
 		assert.NoError(t, err)
@@ -239,7 +238,7 @@ func TestVolumeRemove(t *testing.T) {
 
 	apitests.Run(t, vfs.Name, newTestConfig(t), tf1)
 
-	tf2 := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf2 := func(config gofig.Config, client types.Client, t *testing.T) {
 		err := client.API().VolumeRemove(nil, vfs.Name, "vfs-002")
 		assert.Error(t, err)
 		assert.IsType(t, &types.JSONError{}, err)
@@ -252,7 +251,7 @@ func TestVolumeRemove(t *testing.T) {
 }
 
 func TestVolumeSnapshot(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		volumeID := "vfs-000"
 		snapshotName := "snapshot1"
 		opts := map[string]interface{}{
@@ -292,7 +291,7 @@ func TestVolumeSnapshot(t *testing.T) {
 }
 
 func TestVolumeCreateFromSnapshot(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 
 		ogVol, err := client.API().VolumeInspect(nil, "vfs", "vfs-000", true)
 		assert.NoError(t, err)
@@ -332,7 +331,7 @@ func TestVolumeCreateFromSnapshot(t *testing.T) {
 }
 
 func TestVolumeAttach(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 
 		nextDevice, err := client.Executor().NextDevice(
 			context.Background().WithServiceName(vfs.Name),
@@ -346,12 +345,13 @@ func TestVolumeAttach(t *testing.T) {
 			NextDeviceName: &nextDevice,
 		}
 
-		reply, err := client.API().VolumeAttach(
+		reply, attTokn, err := client.API().VolumeAttach(
 			nil, vfs.Name, "vfs-002", request)
 		assert.NoError(t, err)
 		if reply == nil {
 			t.FailNow()
 		}
+		assert.Equal(t, "1234", attTokn)
 		assert.Equal(t, "vfs-002", reply.ID)
 		assert.Equal(t, "/dev/xvdc", reply.Attachments[0].DeviceName)
 
@@ -360,7 +360,7 @@ func TestVolumeAttach(t *testing.T) {
 }
 
 func TestVolumeDetach(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		request := &types.VolumeDetachRequest{}
 		reply, err := client.API().VolumeDetach(
 			nil, vfs.Name, "vfs-001", request)
@@ -379,7 +379,7 @@ func TestVolumeDetach(t *testing.T) {
 
 func TestVolumeDetachAllForService(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		request := &types.VolumeDetachRequest{}
 		reply, err := client.API().VolumeDetachAllForService(
 			nil, vfs.Name, request)
@@ -406,7 +406,7 @@ func TestVolumeDetachAllForService(t *testing.T) {
 
 func TestVolumeDetachAll(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		request := &types.VolumeDetachRequest{}
 		reply, err := client.API().VolumeDetachAll(
 			nil, request)
@@ -432,7 +432,7 @@ func TestVolumeDetachAll(t *testing.T) {
 }
 
 func TestSnapshotCopy(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		snapshotName := "Snapshot from vfs-000-000"
 
 		opts := map[string]interface{}{
@@ -460,7 +460,7 @@ func TestSnapshotCopy(t *testing.T) {
 }
 
 func TestSnapshotRemove(t *testing.T) {
-	tf := func(config gofig.Config, client client.Client, t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().SnapshotInspect(nil, "vfs", "vfs-000-002")
 		assert.NoError(t, err)
 		assert.NotNil(t, reply)

--- a/libstorage.go
+++ b/libstorage.go
@@ -48,10 +48,6 @@ import (
 	"github.com/emccode/libstorage/client"
 )
 
-func init() {
-	registerConfig()
-}
-
 // RegisterStorageDriver registers a new StorageDriver with the
 // libStorage service.
 func RegisterStorageDriver(
@@ -89,7 +85,7 @@ func Serve(config gofig.Config) (io.Closer, error, <-chan error) {
 // If the config parameter is nil a default instance is created. The
 // function dials the libStorage service specified by the configuration
 // property libstorage.host.
-func Dial(config gofig.Config) (client.Client, error) {
+func Dial(config gofig.Config) (types.Client, error) {
 	return client.New(config)
 }
 
@@ -101,10 +97,10 @@ func Dial(config gofig.Config) (client.Client, error) {
 // While a new server may be launched, it's still up to the caller to provide
 // a config instance with the correct properties to specify service
 // information for a libStorage server.
-func New(config gofig.Config) (client.Client, io.Closer, error, <-chan error) {
+func New(config gofig.Config) (types.Client, io.Closer, error, <-chan error) {
 
 	var (
-		c       client.Client
+		c       types.Client
 		s       io.Closer
 		err     error
 		errs    <-chan error
@@ -142,16 +138,6 @@ func New(config gofig.Config) (client.Client, io.Closer, error, <-chan error) {
 	} else {
 		return c, nil, nil, nil
 	}
-}
-
-func registerConfig() {
-	r := gofig.NewRegistration("libStorage")
-	r.Key(gofig.String, "", "", "", "libstorage.host")
-	r.Key(gofig.String, "", "", "", "libstorage.service")
-	r.Key(gofig.Bool, "", false, "", "libstorage.profiles.enabled")
-	r.Key(gofig.Bool, "", false, "", "libstorage.profiles.client")
-	r.Key(gofig.String, "", "local=127.0.0.1", "", "libstorage.profiles.groups")
-	gofig.Register(r)
 }
 
 const embeddedHostPatt = `libstorage:

--- a/libstorage.json
+++ b/libstorage.json
@@ -455,6 +455,17 @@
         },
 
 
+        "volumeAttachResponse": {
+            "type": "object",
+            "properties": {
+                "volume": { "$ref" : "#/definitions/volume" },
+                "attachToken" : { "type": "string" }
+            },
+            "required": [ "volume", "attachToken" ],
+            "additionalProperties": false
+        },
+
+
         "volumeDetachRequest": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
This patch adds the concept of a Volume Attach Token that's returned as part of an attach operation. The token can be used by the ExecutorCLI's wait function to block until a device has appeared on the system.