### PR TITLE
Fix for HTTP error squashing

### DIFF
--- a/api/client/client_http.go
+++ b/api/client/client_http.go
@@ -83,11 +83,11 @@ func (c *client) httpDo(
 	c.logResponse(res)
 
 	if res.StatusCode > 299 {
-		je := &types.JSONError{}
-		if err := json.NewDecoder(res.Body).Decode(je); err != nil {
+		httpErr, err := goof.DecodeHTTPError(res.Body)
+		if err != nil {
 			return res, goof.WithField("status", res.StatusCode, "http error")
 		}
-		return res, je
+		return res, httpErr
 	}
 
 	if req.Method != http.MethodHead && reply != nil {

--- a/api/server/handlers/handlers_errors.go
+++ b/api/server/handlers/handlers_errors.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"net/http"
 
+	"github.com/akutz/goof"
+
 	"github.com/emccode/libstorage/api/server/httputils"
 	"github.com/emccode/libstorage/api/types"
 )
@@ -39,13 +41,8 @@ func (h *errorHandler) Handle(
 
 	ctx.Error(err)
 
-	jsonError := types.JSONError{
-		Status:     getStatus(err),
-		Message:    err.Error(),
-		InnerError: err,
-	}
-
-	httputils.WriteJSON(w, jsonError.Status, jsonError)
+	httpErr := goof.NewHTTPError(err, getStatus(err))
+	httputils.WriteJSON(w, httpErr.Status(), httpErr)
 	return nil
 }
 

--- a/api/types/types_errors.go
+++ b/api/types/types_errors.go
@@ -4,18 +4,6 @@ import (
 	"github.com/akutz/goof"
 )
 
-// JSONError is the base type for errors returned from the REST API.
-type JSONError struct {
-	Message    string      `json:"message"`
-	Status     int         `json:"status"`
-	InnerError interface{} `json:"error,omitempty"`
-}
-
-// Error returns the error message.
-func (je *JSONError) Error() string {
-	return je.Message
-}
-
 // ErrNotImplemented is the error that Driver implementations should return if
 // a function is not implemented.
 var ErrNotImplemented = goof.New("not implemented")

--- a/drivers/storage/mock/mock_driver.go
+++ b/drivers/storage/mock/mock_driver.go
@@ -157,6 +157,17 @@ func (d *driver) VolumeCreate(
 	name string,
 	opts *types.VolumeCreateOpts) (*types.Volume, error) {
 
+	if name == "Volume 010" {
+		return nil, goof.WithFieldE(
+			"iops", opts.IOPS,
+			"iops required",
+			goof.WithFieldE(
+				"size", opts.Size,
+				"size required",
+				goof.New("bzzzzT BROKEN"),
+			),
+		)
+	}
 	lenVols := len(d.volumes)
 
 	volume := &types.Volume{

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -15,6 +15,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/akutz/gofig"
+	"github.com/akutz/goof"
 	"github.com/akutz/gotil"
 	"github.com/stretchr/testify/assert"
 
@@ -241,10 +242,9 @@ func TestVolumeRemove(t *testing.T) {
 	tf2 := func(config gofig.Config, client types.Client, t *testing.T) {
 		err := client.API().VolumeRemove(nil, vfs.Name, "vfs-002")
 		assert.Error(t, err)
-		assert.IsType(t, &types.JSONError{}, err)
-		je := err.(*types.JSONError)
-		assert.Equal(t, "resource not found", je.Error())
-		assert.Equal(t, 404, je.Status)
+		httpErr := err.(goof.HTTPError)
+		assert.Equal(t, "resource not found", httpErr.Error())
+		assert.Equal(t, 404, httpErr.Status())
 	}
 
 	apitests.RunGroup(t, vfs.Name, newTestConfig(t), tf1, tf2)


### PR DESCRIPTION
This patch provides a fix for the HTTP error squashing. The fix is actually provided in the Goof library, which introduces a new type of `HTTPError` as well as both its marshaler and decoder.

To prove this, run `LIBSTORAGE_DEBUG=true go test -v ./drivers/storage/mock/tests -run TestVolumeCreateWithError`

This will validate that the HTTP error sent back to the client:

```
INFO[0001]     -------------------------- HTTP RESPONSE (SERVER) ------------------------- 
INFO[0001]     Content-Type=application/json            
INFO[0001]                                              
INFO[0001]     {                                        
INFO[0001]       "message": "iops required",            
INFO[0001]       "status": 500,                         
INFO[0001]       "error": {                             
INFO[0001]         "inner": {                           
INFO[0001]           "inner": "bzzzzT BROKEN",          
INFO[0001]           "msg": "size required",            
INFO[0001]           "size": 10240                      
INFO[0001]         },                                   
INFO[0001]         "iops": 1000                         
INFO[0001]       }                                      
INFO[0001]     }     
```

is the same as the error that's parsed inside the client HTTP package:

```
	if res.StatusCode > 299 {
		httpErr, err := goof.DecodeHTTPError(res.Body)
		if err != nil {
			return res, goof.WithField("status", res.StatusCode, "http error")
		}
		return res, httpErr
	}
```

```
		expectedError := goof.NewHTTPError(goof.WithFieldE(
			"iops", volumeCreateRequest.IOPS,
			"iops required",
			goof.WithFieldE(
				"size", volumeCreateRequest.Size,
				"size required",
				goof.New("bzzzzT BROKEN"),
			),
		), 500)

		_, err := client.API().VolumeCreate(
			nil, mock.Name, volumeCreateRequest)

		assert.Error(t, err)

		expBuf, _ := json.Marshal(expectedError)
		actBuf, _ := json.Marshal(err)
		assert.EqualValues(t, expBuf, actBuf)
```