### PR TITLE
TLS Update

### DIFF
--- a/api/server/server_config.go
+++ b/api/server/server_config.go
@@ -9,6 +9,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/akutz/gofig"
+
+	apiconfig "github.com/emccode/libstorage/api/utils/config"
 )
 
 var (
@@ -76,7 +78,10 @@ func NewConfig(
 	if host == "" {
 		host = "tcp://127.0.0.1:7979"
 	}
-	config := gofig.New()
+	config, err := apiconfig.NewConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	if debug, _ := strconv.ParseBool(os.Getenv("LIBSTORAGE_DEBUG")); debug {
 		log.SetLevel(log.DebugLevel)

--- a/api/server/server_control.go
+++ b/api/server/server_control.go
@@ -96,6 +96,11 @@ func newServer(config gofig.Config) (*server, error) {
 		}
 	}
 
+	if s := config.GetScope(); s != "" {
+		config = config.Scope(fmt.Sprintf("%s.%s", s, types.ConfigServer))
+	}
+	config = config.Scope(types.ConfigServer)
+
 	ctx := context.Background().WithConfig(config)
 
 	s := &server{

--- a/api/types/types_config.go
+++ b/api/types/types_config.go
@@ -81,4 +81,25 @@ const (
 
 	// ConfigClientCacheInstanceID is a config key.
 	ConfigClientCacheInstanceID = ConfigClient + ".cache.instanceID"
+
+	// ConfigTLS is a config key.
+	ConfigTLS = ConfigRoot + ".tls"
+
+	// ConfigTLSDisabled is a config key.
+	ConfigTLSDisabled = ConfigTLS + ".disabled"
+
+	// ConfigTLSServerName is a config key.
+	ConfigTLSServerName = ConfigTLS + ".serverName"
+
+	// ConfigTLSClientCertRequired is a config key.
+	ConfigTLSClientCertRequired = ConfigTLS + ".clientCertRequired"
+
+	// ConfigTLSTrustedCertsFile is a config key.
+	ConfigTLSTrustedCertsFile = ConfigTLS + ".trustedCertsFile"
+
+	// ConfigTLSCertFile is a config key.
+	ConfigTLSCertFile = ConfigTLS + ".certFile"
+
+	// ConfigTLSKeyFile is a config key.
+	ConfigTLSKeyFile = ConfigTLS + ".keyFile"
 )

--- a/client/client.go
+++ b/client/client.go
@@ -1,11 +1,14 @@
 package client
 
 import (
+	"fmt"
+
 	"github.com/akutz/gofig"
 
 	"github.com/emccode/libstorage/api/context"
 	"github.com/emccode/libstorage/api/registry"
 	"github.com/emccode/libstorage/api/types"
+	apicnfg "github.com/emccode/libstorage/api/utils/config"
 
 	// load the local imports
 	_ "github.com/emccode/libstorage/imports/local"
@@ -23,6 +26,18 @@ type client struct {
 
 // New returns a new libStorage client.
 func New(config gofig.Config) (types.Client, error) {
+
+	if config == nil {
+		var err error
+		if config, err = apicnfg.NewConfig(); err != nil {
+			return nil, err
+		}
+	}
+
+	if s := config.GetScope(); s != "" {
+		config = config.Scope(fmt.Sprintf("%s.%s", s, types.ConfigClient))
+	}
+	config = config.Scope(types.ConfigClient)
 
 	var (
 		c   *client


### PR DESCRIPTION
This patch updates the TLS config paths as well as ensuring the scope is correct for different Client and Server TLS configs.

### Example libStorage Config with TLS
```
libstorage:
  tls:
    serverName: libstorage-server
    clientCertRequired: true
    trustedCertsFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-ca.crt
  service: vfs
  logging:
    httpRequests: true
    httpResponses: true
  client:
    libstorage:
      tls:
        certFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-client.crt
        keyFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-client.key
  server:
    libstorage:
      tls:
        certFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-server.crt
        keyFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-server.key
    services:
      vfs:
        libstorage:
          storage:
            driver: vfs
      mock:
        libstorage:
          storage:
          driver: mock
```

### Example REX-Ray Config with TLS
```
rexray:
  modules:
    default-docker:
      libstorage:
        tls:
          serverName: libstorage-server
          clientCertRequired: true
          trustedCertsFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-ca.crt
        service: vfs
        logging:
          httpRequests: true
          httpResponses: true
        client:
          libstorage:
            tls:
              certFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-client.crt
              keyFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-client.key
        server:
          libstorage:
            tls:
              certFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-server.crt
              keyFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-server.key
          services:
            vfs:
              libstorage:
                storage:
                  driver: vfs
            mock:
              libstorage:
                storage:
                  driver: mock
```

It's also possible to disable TLS without removing all the keys. Under the `tls` key (at any of the known scopes), place `disabled: true`. For example, here's the libStorage config with all of the TLS settings, but the server has TLS disabled:

### Example libStorage Config with TLS Disabled
```
libstorage:
  tls:
    serverName: libstorage-server
    clientCertRequired: true
    trustedCertsFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-ca.crt
  service: vfs
  logging:
    httpRequests: true
    httpResponses: true
  client:
    libstorage:
      tls:
        certFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-client.crt
        keyFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-client.key
  server:
    libstorage:
      tls:
        disabled: true
        certFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-server.crt
        keyFile: /Users/akutz/Projects/go/src/github.com/emccode/libstorage/.tls/libstorage-server.key
    services:
      vfs:
        libstorage:
          storage:
            driver: vfs
      mock:
        libstorage:
          storage:
          driver: mock
```