### PR TITLE
Local Devices & Path Fix

### DIFF
--- a/api/utils/paths/paths.go
+++ b/api/utils/paths/paths.go
@@ -217,10 +217,17 @@ var (
 	slashRX        = regexp.MustCompile(`^((?:/)|(?:[a-zA-Z]\:\\?))?$`)
 )
 
+// TODO Fix this logic
 func init() {
-	if libstorageHome == "" && os.Geteuid() != 0 {
+	if libstorageHome == "" {
+		libstorageHome = "/"
+	}
+
+	// if not root and home is /, change home to user's home dir
+	if os.Geteuid() != 0 && libstorageHome == "/" {
 		libstorageHome = Join(gotil.HomeDir(), ".libstorage")
 	}
+
 	thisExeDir, thisExeName, thisExeAbsPath = gotil.GetThisPathParts()
 }
 

--- a/drivers/storage/libstorage/libstorage_client.go
+++ b/drivers/storage/libstorage/libstorage_client.go
@@ -19,7 +19,8 @@ type client struct {
 	types.APIClient
 	ctx             types.Context
 	config          gofig.Config
-	svcAndLSXCache  *lss
+	serviceCache    *lss
+	lsxCache        *lss
 	instanceIDCache types.Store
 }
 
@@ -68,7 +69,7 @@ func getHost(proto, lAddr string, tlsConfig *tls.Config) string {
 }
 
 func (c *client) getServiceInfo(service string) (*types.ServiceInfo, error) {
-	if si := c.svcAndLSXCache.GetServiceInfo(service); si != nil {
+	if si := c.serviceCache.GetServiceInfo(service); si != nil {
 		return si, nil
 	}
 	return nil, goof.WithField("name", service, "unknown service")
@@ -78,7 +79,7 @@ func (c *client) updateExecutor(ctx types.Context) error {
 
 	ctx.Debug("updating executor")
 
-	lsxi := c.svcAndLSXCache.GetExecutorInfo(types.LSX)
+	lsxi := c.lsxCache.GetExecutorInfo(types.LSX)
 	if lsxi == nil {
 		return goof.WithField("lsx", types.LSX, "unknown executor")
 	}

--- a/drivers/storage/libstorage/libstorage_driver.go
+++ b/drivers/storage/libstorage/libstorage_driver.go
@@ -98,7 +98,8 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 		APIClient:       apiClient,
 		ctx:             ctx,
 		config:          config,
-		svcAndLSXCache:  &lss{Store: utils.NewStore()},
+		serviceCache:    &lss{Store: utils.NewStore()},
+		lsxCache:        &lss{Store: utils.NewStore()},
 		instanceIDCache: &lss{Store: newIIDCache()},
 	}
 

--- a/drivers/storage/mock/mock_driver.go
+++ b/drivers/storage/mock/mock_driver.go
@@ -115,21 +115,21 @@ func (d *driver) Volumes(
 		d.volumes[0].Attachments = []*types.VolumeAttachment{
 			&types.VolumeAttachment{
 				DeviceName: "/dev/xvda",
-				MountPoint: "/var/log",
+				MountPoint: ctx.LocalDevices()["/dev/xvda"],
 				InstanceID: ctx.InstanceID(),
 				Status:     "attached",
 				VolumeID:   d.volumes[0].ID,
 			},
 			&types.VolumeAttachment{
 				DeviceName: "/dev/xvdb",
-				MountPoint: "/home",
+				MountPoint: ctx.LocalDevices()["/dev/xvdb"],
 				InstanceID: ctx.InstanceID(),
 				Status:     "attached",
 				VolumeID:   d.volumes[1].ID,
 			},
 			&types.VolumeAttachment{
 				DeviceName: "/dev/xvdc",
-				MountPoint: "/net/share",
+				MountPoint: ctx.LocalDevices()["/dev/xvdc"],
 				InstanceID: ctx.InstanceID(),
 				Status:     "attached",
 				VolumeID:   d.volumes[2].ID,


### PR DESCRIPTION
This patch fixes a bug where local devices were no longer being sent with the API calls that required them. Additionally, the logic to arrive at the libStorage home directory has been updated so that if `LIBSTORAGE_HOME` is not set, it is set to `/`. And if the process is running as non-root, the home dir is changed once again to `.libstorage` under the `$HOME` directory of the owning process user.