### PR TITLE
Reduce Log Verbosity

### DIFF
--- a/api/context/context_test.go
+++ b/api/context/context_test.go
@@ -3,7 +3,6 @@ package context
 import (
 	"testing"
 
-	"github.com/akutz/gofig"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/emccode/libstorage/api/types"
@@ -32,32 +31,4 @@ func TestContextIDLog(t *testing.T) {
 	ctx.Info("no storage driver")
 	ctx = ctx.WithContextSID(types.ContextStorageDriver, "mock")
 	ctx.Info("storage driver set")
-}
-
-func TestConfig(t *testing.T) {
-
-	assertEmpty := func(configs ...gofig.Config) {
-		for _, c := range configs {
-			assert.Empty(t, c.GetString("hello"))
-		}
-	}
-
-	assertEqual := func(configs ...gofig.Config) {
-		for _, c := range configs {
-			assert.Equal(t, "world", c.GetString("hello"))
-		}
-	}
-
-	config := gofig.New()
-	ctx := NewContext(Background(), config, nil)
-	assertEmpty(config, ctx)
-
-	config.Set("hello", "world")
-	assertEqual(config, ctx)
-
-	ctx = ctx.WithServiceName("mock")
-	assertEqual(ctx)
-
-	ctx2 := Background().Join(ctx)
-	assertEqual(ctx2)
 }

--- a/api/server/server_control.go
+++ b/api/server/server_control.go
@@ -98,7 +98,7 @@ func newServer(config gofig.Config) (*server, error) {
 
 	config = config.Scope(types.ConfigServer)
 
-	ctx := context.Background().WithConfig(config)
+	ctx := context.Background()
 
 	s := &server{
 		name:         randomServerName(),

--- a/api/types/types_context.go
+++ b/api/types/types_context.go
@@ -6,14 +6,12 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/akutz/gofig"
 	"golang.org/x/net/context"
 )
 
 // Context is a libStorage context.
 type Context interface {
 	context.Context
-	gofig.Config
 	log.FieldLogger
 
 	// Join joins this context with another, such that value lookups will first
@@ -57,9 +55,6 @@ type Context interface {
 
 	// Client returns this context's client.
 	Client() Client
-
-	// WithConfig returns a context with the provided config.
-	WithConfig(config gofig.Config) Context
 
 	// WithHTTPRequest returns a context with the provided HTTP request.
 	WithHTTPRequest(req *http.Request) Context
@@ -124,9 +119,6 @@ func (ck ContextKey) String() string {
 const (
 	// ContextHTTPRequest is a context key.
 	ContextHTTPRequest ContextKey = 5000 + iota
-
-	// ContextConfig is a context key.
-	ContextConfig
 
 	// ContextLogger is a context key.
 	ContextLogger

--- a/client/client.go
+++ b/client/client.go
@@ -39,7 +39,7 @@ func New(config gofig.Config) (types.Client, error) {
 		err error
 	)
 
-	c = &client{ctx: context.Background().WithConfig(config), config: config}
+	c = &client{ctx: context.Background(), config: config}
 	c.ctx = c.ctx.WithClient(c)
 
 	if config.IsSet(types.ConfigService) {


### PR DESCRIPTION
This fix updates the Context type to no longer act as a mixin with gofig.Config. The result is that new contexts are not also causing new Config instances to be created, thereby reducing the overall logging immensely.