### PR TITLE
Updates and fixes for the virtualbox driver

### DIFF
--- a/drivers/storage/vbox/executor/vbox_executor.go
+++ b/drivers/storage/vbox/executor/vbox_executor.go
@@ -94,7 +94,10 @@ func (d *driver) LocalDevices(
 		return nil, err
 	}
 
-	d.rescanScsiHosts()
+	if opts.ScanType == types.DeviceScanDeep {
+		d.rescanScsiHosts()
+	}
+
 	for _, f := range files {
 		if strings.Contains(f.Name(), "VBOX_HARDDISK_VB") {
 			sid := d.getShortDeviceID(f.Name())


### PR DESCRIPTION
This commit fixes some object releases and includes an update
for the scantype functionality to ensure only requested
scandeep operations invoke expensive operations for discovery.