### PR TITLE
Fix for Glide Lock File

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - go get golang.org/x/tools/cmd/cover
   - GBD_GIT=https://github.com/akutz/go-bindata.git; GBD_DIR=$GOPATH/src/github.com/jteeuwen/go-bindata; mkdir -p $GBD_DIR && cd $GBD_DIR && git clone $GBD_GIT . && git checkout feature/md5checksum && go install ./... && cd -
 script:
-  - make glide.lock
+  - make glide.lock.d
   - make -j cover
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ endif
 GOGET_LOCK := goget.lock
 GLIDE_LOCK := glide.lock
 GLIDE_YAML := glide.yaml
+GLIDE_LOCK_D := glide.lock.d
 
 EXT_DEPS := $(sort $(EXT_DEPS))
 EXT_DEPS_SRCS := $(sort $(EXT_DEPS_SRCS))
@@ -205,11 +206,14 @@ ALL_EXT_DEPS := $(sort $(EXT_DEPS) $(TEST_EXT_DEPS))
 ALL_EXT_DEPS_SRCS := $(sort $(EXT_DEPS_SRCS) $(TEST_EXT_DEPS_SRCS))
 
 ifneq (1,$(VENDORED))
-ifneq (,$(GLIDE_YAML))
-$(ALL_EXT_DEPS_SRCS): $(GLIDE_LOCK)
+ifneq (,$(wildcard $(GLIDE_YAML)))
+$(ALL_EXT_DEPS_SRCS): $(GLIDE_LOCK_D)
+
+$(GLIDE_LOCK_D): $(GLIDE_LOCK)
+	glide up && touch $@
 
 $(GLIDE_LOCK): $(GLIDE_YAML)
-	glide up
+	touch $@
 
 $(GLIDE_LOCK)-clean:
 	rm -f $(GLIDE_LOCK)


### PR DESCRIPTION
This patch fixes an issue where now that the glide lock file is checked in, glide was not running. This patch introduces `glide.lock.d` to ensure that glide is executed even if the glide lock file is present.