### PR TITLE
GCC99 Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,14 @@ install:
   - GBD_GIT=https://github.com/akutz/go-bindata.git; GBD_DIR=$GOPATH/src/github.com/jteeuwen/go-bindata; mkdir -p $GBD_DIR && cd $GBD_DIR && git clone $GBD_GIT . && git checkout feature/md5checksum && go install ./... && cd -
 script:
   - make glide.lock.d
+  - make -j
   - make -j cover
 cache:
   directories:
   - vendor
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8

--- a/c/libstor-c.c
+++ b/c/libstor-c.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include "libstor-c.h"
 
 int main(int argc, char** argv) {
@@ -35,8 +36,8 @@ int main(int argc, char** argv) {
             printf("\n");
             printf("  - volume: %s\n", vm.volume_ids[y]);
             printf("            name:   %s\n", vol.name);
-            printf("            iops:   %lld\n", vol.iops);
-            printf("            size:   %lld\n", vol.size);
+            printf("            iops:   %" PRId64 "\n", vol.iops);
+            printf("            size:   %" PRId64 "\n", vol.size);
             printf("            type:   %s\n", vol.volume_type);
             printf("            zone:   %s\n", vol.availability_zone);
             printf("            status: %s\n", vol.status);

--- a/cli/semaphores/open.c
+++ b/cli/semaphores/open.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <semaphore.h>
 #include <errno.h>
+#include <fcntl.h>
 
 int main(int argc, char** argv) {
 	if (argc < 2) {

--- a/cli/semaphores/signal.c
+++ b/cli/semaphores/signal.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <semaphore.h>
 #include <errno.h>
+#include <fcntl.h>
 
 int main(int argc, char** argv) {
 	if (argc < 2) {

--- a/cli/semaphores/wait.c
+++ b/cli/semaphores/wait.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <semaphore.h>
 #include <errno.h>
+#include <fcntl.h>
 
 int main(int argc, char** argv) {
 	if (argc < 2) {


### PR DESCRIPTION
This patch updates the Makefile to be compliant with GCC99 as well as replaces the hardcoded uses of `gcc` with $(CC) in order to inject the GCC calls with the necessary flags:

```
CC := gcc -Wall -pedantic -std=c99
```