### PR TITLE
Go-bindata Proper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ install:
   - go get github.com/onsi/gomega
   - go get github.com/onsi/ginkgo
   - go get golang.org/x/tools/cmd/cover
-  - GBD_GIT=https://github.com/akutz/go-bindata.git; GBD_DIR=$GOPATH/src/github.com/jteeuwen/go-bindata; mkdir -p $GBD_DIR && cd $GBD_DIR && git clone $GBD_GIT . && git checkout feature/md5checksum && go install ./... && cd -
 script:
-  - make glide.lock.d
+  - make deps
   - make -j
   - make -j cover
 cache:

--- a/api/server/executors/executors.go
+++ b/api/server/executors/executors.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"regexp"
 
+	// depend upon this tool with a nil import in order to preserve it
+	// in the dependency list
+	_ "github.com/jteeuwen/go-bindata"
+
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/utils"
 )

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b6ce4db8859652b3409531cfd29d1beeda92e8607d9e7d5c491a29f09cdf7462
-updated: 2016-05-11T15:04:35.328798636-05:00
+hash: a40b76f83c0a061d7e78be85db4b98d3dc59dce7d6128a33353ed30fd8c028ab
+updated: 2016-05-11T18:47:36.326739551-05:00
 imports:
 - name: github.com/akutz/gofig
   version: 84e1fb25c0a0fd2f2da6d7ce7827881f7c80eef5
@@ -43,6 +43,9 @@ imports:
   version: a8d44e7d8e4d532b6a27a02dd82abb31cc1b01bd
 - name: github.com/gorilla/mux
   version: 9c19ed558d5df4da88e2ade9c8940d742aef0e7e
+- name: github.com/jteeuwen/go-bindata
+  version: 1dd44b25b79c4d9060e582e90798e4d72537818c
+  repo: https://github.com/akutz/go-bindata
 - name: github.com/kardianos/osext
   version: 29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc
   repo: https://github.com/kardianos/osext.git

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,3 +21,6 @@ import:
     ref:     e0978ab2ed407095400a69d5933958dd260058cd
     repo:    https://github.com/clintonskitson/go-virtualboxclient
     vcs:     git
+  - package: github.com/jteeuwen/go-bindata
+    ref:     feature/md5checksum
+    repo:    https://github.com/akutz/go-bindata


### PR DESCRIPTION
This patch automatically fetches go-bindata as part of `glide.yaml` and will build it from that source if it does not exist. Projects that vendor libStorage should not have to do anything special with regards to `go-bindata` as long as said projects are using Glide. The libStorage Makefile's `executors` target which projects that embed libStorage already execute now depends on the target that builds `go-bindata`.