### PR TITLE
Fixed vbox and scaleio for latest updates to context

### DIFF
--- a/drivers/storage/libstorage/libstorage_client_api.go
+++ b/drivers/storage/libstorage/libstorage_client_api.go
@@ -73,15 +73,15 @@ func (c *client) Volumes(
 
 	ctx = c.requireCtx(ctx)
 
-	if attachments {
-		ctxA, err := c.withAllLocalDevices(ctx)
-		if err != nil {
-			return nil, err
-		}
-		ctx = ctxA
-
-		ctx = c.withAllInstanceIDs(ctx)
+	// if attachments {
+	ctxA, err := c.withAllLocalDevices(ctx)
+	if err != nil {
+		return nil, err
 	}
+	ctx = ctxA
+
+	ctx = c.withAllInstanceIDs(ctx)
+	// }
 
 	return c.APIClient.Volumes(ctx, attachments)
 }
@@ -93,14 +93,14 @@ func (c *client) VolumesByService(
 
 	ctx = c.requireCtx(ctx).WithValue(context.ServiceKey, service)
 
-	if attachments {
-		ctxA, err := c.withAllLocalDevices(ctx)
-		if err != nil {
-			return nil, err
-		}
-		ctx = ctxA
-		ctx = c.withInstanceID(ctx, service)
+	// if attachments {
+	ctxA, err := c.withAllLocalDevices(ctx)
+	if err != nil {
+		return nil, err
 	}
+	ctx = ctxA
+	ctx = c.withInstanceID(ctx, service)
+	// }
 
 	return c.APIClient.VolumesByService(ctx, service, attachments)
 }
@@ -112,14 +112,14 @@ func (c *client) VolumeInspect(
 
 	ctx = c.requireCtx(ctx).WithValue(context.ServiceKey, service)
 
-	if attachments {
-		ctxA, err := c.withAllLocalDevices(ctx)
-		if err != nil {
-			return nil, err
-		}
-		ctx = ctxA
-		ctx = c.withInstanceID(ctx, service)
+	// if attachments {
+	ctxA, err := c.withAllLocalDevices(ctx)
+	if err != nil {
+		return nil, err
 	}
+	ctx = ctxA
+	ctx = c.withInstanceID(ctx, service)
+	// }
 
 	return c.APIClient.VolumeInspect(ctx, service, volumeID, attachments)
 }
@@ -130,6 +130,12 @@ func (c *client) VolumeCreate(
 	request *types.VolumeCreateRequest) (*types.Volume, error) {
 
 	ctx = c.requireCtx(ctx).WithValue(context.ServiceKey, service)
+	ctxA, err := c.withAllLocalDevices(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ctx = ctxA
+	ctx = c.withInstanceID(ctx, service)
 
 	lsd, _ := registry.NewClientDriver(service)
 	if lsd != nil {
@@ -255,6 +261,16 @@ func (c *client) VolumeAttach(
 	request *types.VolumeAttachRequest) (*types.Volume, string, error) {
 
 	ctx = c.withInstanceID(c.requireCtx(ctx), service)
+	ctxA, err := c.withAllLocalDevices(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	ctx = ctxA
+	ctx, err = c.withAllLocalDevices(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+
 	return c.APIClient.VolumeAttach(ctx, service, volumeID, request)
 }
 
@@ -265,6 +281,12 @@ func (c *client) VolumeDetach(
 	request *types.VolumeDetachRequest) (*types.Volume, error) {
 
 	ctx = c.withInstanceID(c.requireCtx(ctx), service)
+	ctxA, err := c.withAllLocalDevices(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ctx = ctxA
+
 	return c.APIClient.VolumeDetach(ctx, service, volumeID, request)
 }
 
@@ -273,6 +295,12 @@ func (c *client) VolumeDetachAll(
 	request *types.VolumeDetachRequest) (types.ServiceVolumeMap, error) {
 
 	ctx = c.withAllInstanceIDs(c.requireCtx(ctx))
+	ctxA, err := c.withAllLocalDevices(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ctx = ctxA
+
 	return c.APIClient.VolumeDetachAll(ctx, request)
 }
 
@@ -282,6 +310,12 @@ func (c *client) VolumeDetachAllForService(
 	request *types.VolumeDetachRequest) (types.VolumeMap, error) {
 
 	ctx = c.withInstanceID(c.requireCtx(ctx), service)
+	ctxA, err := c.withAllLocalDevices(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ctx = ctxA
+
 	return c.APIClient.VolumeDetachAllForService(ctx, service, request)
 }
 

--- a/drivers/storage/scaleio/storage/scaleio_storage.go
+++ b/drivers/storage/scaleio/storage/scaleio_storage.go
@@ -128,12 +128,17 @@ func (d *driver) InstanceInspect(
 	ctx types.Context,
 	opts types.Store) (*types.Instance, error) {
 
+	iid := context.MustInstanceID(ctx)
+	if iid.ID != "" && iid.Formatted == true {
+		return &types.Instance{InstanceID: iid}, nil
+	}
+
 	//if transformed return
 	guid, _, err := d.verifySdc(ctx, context.MustInstanceID(ctx).ID)
 	if err != nil {
 		return nil, goof.WithError("problem looking up instanceID", err)
 	}
-	iid := &types.InstanceID{
+	iid = &types.InstanceID{
 		ID: guid,
 	}
 

--- a/drivers/storage/vbox/storage/vbox_storage.go
+++ b/drivers/storage/vbox/storage/vbox_storage.go
@@ -73,6 +73,7 @@ func (d *driver) LocalDevices(
 	if ld, ok := context.LocalDevices(ctx); ok {
 		return ld, nil
 	}
+	panic("here1")
 	return nil, goof.New("missing local devices")
 }
 
@@ -99,7 +100,7 @@ func getMacs(ctx types.Context) []string {
 	iid := context.MustInstanceID(ctx)
 	var macs []string
 	if err := json.Unmarshal(iid.Metadata, &macs); err != nil {
-		panic(err)
+		return nil
 	}
 
 	ctx.WithField("instanceID", iid.ID).Debug("checking instance ID")
@@ -131,6 +132,11 @@ func (d *driver) getInstanceID(
 func (d *driver) InstanceInspect(
 	ctx types.Context,
 	opts types.Store) (*types.Instance, error) {
+
+	iid := context.MustInstanceID(ctx)
+	if iid.ID != "" {
+		return &types.Instance{InstanceID: iid}, nil
+	}
 
 	d.refreshSession(ctx)
 


### PR DESCRIPTION
This commit fixes some issues in the scaleio and virtualbox
driver packages relating to using the new context. It also
include exposing instanceID and localdevices further than
planned to make the drivers work for mount/unmount/attach
/detach operations.