### PR TITLE
Disable Mock Driver

### DIFF
--- a/drivers/storage/mock/executor/mock_executor.go
+++ b/drivers/storage/mock/executor/mock_executor.go
@@ -1,3 +1,5 @@
+// +build mock
+
 package executor
 
 import (

--- a/drivers/storage/mock/mock_driver.go
+++ b/drivers/storage/mock/mock_driver.go
@@ -1,3 +1,5 @@
+// +build mock
+
 package mock
 
 import (

--- a/drivers/storage/mock/tests/mock_test.go
+++ b/drivers/storage/mock/tests/mock_test.go
@@ -1,3 +1,5 @@
+// +build mock
+
 package mock
 
 import (

--- a/drivers/storage/vfs/executor/vfs_executor.go
+++ b/drivers/storage/vfs/executor/vfs_executor.go
@@ -64,7 +64,13 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 func (d *driver) InstanceID(
 	ctx types.Context,
 	opts types.Store) (*types.InstanceID, error) {
-	return instanceID()
+
+	hostName, err := utils.HostName()
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.InstanceID{ID: hostName, Driver: vfs.Name}, nil
 }
 
 var (
@@ -168,14 +174,6 @@ func (d *driver) LocalDevices(
 	}
 
 	return &types.LocalDevices{Driver: vfs.Name, DeviceMap: localDevs}, nil
-}
-
-func instanceID() (*types.InstanceID, error) {
-	hostName, err := utils.HostName()
-	if err != nil {
-		return nil, err
-	}
-	return &types.InstanceID{ID: hostName, Driver: vfs.Name}, nil
 }
 
 var initialDeviceFile = []byte(`/dev/xvda

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: a40b76f83c0a061d7e78be85db4b98d3dc59dce7d6128a33353ed30fd8c028ab
-updated: 2016-05-11T18:47:36.326739551-05:00
+updated: 2016-05-12T12:47:33.754933078-05:00
 imports:
 - name: github.com/akutz/gofig
   version: 84e1fb25c0a0fd2f2da6d7ce7827881f7c80eef5
@@ -88,7 +88,7 @@ imports:
   - context/ctxhttp
   - context
 - name: golang.org/x/sys
-  version: 806cb00533e5af545ce95e84b349404f8e5ff7a8
+  version: e82cb4d7dffc35bcec7bc8bf9e402377e0ecf3f4
   subpackages:
   - unix
 - name: gopkg.in/fsnotify.v1

--- a/imports/executors/imports_executor.go
+++ b/imports/executors/imports_executor.go
@@ -5,7 +5,6 @@ import (
 	//_ "github.com/emccode/libstorage/drivers/storage/ec2/executor"
 	//_ "github.com/emccode/libstorage/drivers/storage/gce/executor"
 	//_ "github.com/emccode/libstorage/drivers/storage/isilon/executor"
-	_ "github.com/emccode/libstorage/drivers/storage/mock/executor"
 	//_ "github.com/emccode/libstorage/drivers/storage/openstack/executor"
 	//_ "github.com/emccode/libstorage/drivers/storage/rackspace/executor"
 	_ "github.com/emccode/libstorage/drivers/storage/scaleio/executor"

--- a/imports/remote/imports_remote.go
+++ b/imports/remote/imports_remote.go
@@ -2,7 +2,6 @@ package remote
 
 import (
 	// import to load
-	_ "github.com/emccode/libstorage/drivers/storage/mock"
 	_ "github.com/emccode/libstorage/drivers/storage/scaleio/storage"
 	_ "github.com/emccode/libstorage/drivers/storage/vbox/storage"
 	_ "github.com/emccode/libstorage/drivers/storage/vfs/storage"


### PR DESCRIPTION
This patch disables the Mock driver and its tests. All framework testing has been ported into the VFS driver's tests.