### PR TITLE
Fixes instanceID lookup and metadata

### DIFF
--- a/drivers/storage/scaleio/executor/scaleio_executor.go
+++ b/drivers/storage/scaleio/executor/scaleio_executor.go
@@ -130,9 +130,11 @@ func GetInstanceID() (*types.InstanceID, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &types.InstanceID{
-		ID: sg,
-	}, nil
+	iid := &types.InstanceID{Driver: Name}
+	if err := iid.MarshalMetadata(sg); err != nil {
+		return nil, err
+	}
+	return iid, nil
 }
 
 func getSdcLocalGUID() (sdcGUID string, err error) {

--- a/drivers/storage/scaleio/storage/scaleio_storage.go
+++ b/drivers/storage/scaleio/storage/scaleio_storage.go
@@ -465,10 +465,7 @@ func (d *driver) VolumeAttach(
 	volumeID string,
 	opts *types.VolumeAttachOpts) (*types.Volume, string, error) {
 
-	iid, iidOK := context.InstanceID(ctx)
-	if !iidOK {
-		return nil, "", goof.New("missing instanceID")
-	}
+	iid := context.MustInstanceID(ctx)
 
 	mapVolumeSdcParam := &siotypes.MapVolumeSdcParam{
 		SdcID: iid.ID,


### PR DESCRIPTION
This commit fixes the instanceID lookup for ScaleIO. It ensures
that metadata is now used to send the introspected sdc guid
and then allows the InstanceID to be translated into the ID
field.