### PR TITLE
Added custom headers to API methods

### DIFF
--- a/api/client/client_http.go
+++ b/api/client/client_http.go
@@ -31,6 +31,10 @@ func (c *client) httpDo(
 		return nil, err
 	}
 
+	for k, v := range c.headers {
+		req.Header[k] = v
+	}
+
 	ctx = context.RequireTX(ctx)
 	tx := context.MustTransaction(ctx)
 	req.Header.Set(types.TransactionHeader, tx.String())

--- a/api/types/types_clients.go
+++ b/api/types/types_clients.go
@@ -44,6 +44,16 @@ type APIClient interface {
 	// LogResponses enables or disables the logging of client HTTP responses.
 	LogResponses(enabled bool)
 
+	// AddHeader provides the API client with a key/value pair that are
+	// added to all outgoing HTTP requests as a header.
+	AddHeader(key, value string)
+
+	// AddHeaderForDriver is a variant of AddHeader and adds a header in the
+	// format HEADER_KEY: DRIVER_NAME=HEADER_VALUE_KEY=HEADER_VALUE_VALUE.
+	// If there's an existing header with the same HEADER_KEY and
+	// DRIVER_NAME it is replaced.
+	AddHeaderForDriver(driverName, key, value string)
+
 	// Root returns a list of root resources.
 	Root(ctx Context) ([]string, error)
 


### PR DESCRIPTION
This commit re-introduces the ability to set customer header
values from the API client.

I haven't been able to fully end to end test this yet, but I believe this may be what is needed.