### PR TITLE
Custom Header/Logger Context Keys

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3,8 +3,15 @@ package client
 import (
 	"net/http"
 
+	"github.com/emccode/libstorage/api/context"
 	"github.com/emccode/libstorage/api/types"
 )
+
+func init() {
+	context.RegisterCustomKey(transactionHeaderKey, context.CustomHeaderKey)
+	context.RegisterCustomKey(instanceIDHeaderKey, context.CustomHeaderKey)
+	context.RegisterCustomKey(localDevicesHeaderKey, context.CustomHeaderKey)
+}
 
 // Client is the libStorage API client.
 type client struct {

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -91,6 +91,9 @@ func WithStorageService(
 // WithValue returns a copy of parent in which the value associated with
 // key is val.
 func WithValue(ctx context.Context, key, val interface{}) types.Context {
+	if customKeyID, ok := isCustomKey(key); ok {
+		key = customKeyID
+	}
 	return newContext(context.WithValue(ctx, key, val), nil, nil)
 }
 
@@ -106,6 +109,10 @@ func Value(ctx context.Context, key interface{}) interface{} {
 }
 
 func (ctx *lsc) Value(key interface{}) interface{} {
+
+	if customKeyID, ok := isCustomKey(key); ok {
+		key = customKeyID
+	}
 
 	if key == HTTPRequestKey {
 		return ctx.req

--- a/api/context/context_test.go
+++ b/api/context/context_test.go
@@ -1,10 +1,30 @@
 package context
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	RegisterCustomKey(testLogKeyHello, CustomLoggerKey|CustomHeaderKey)
+	os.Exit(m.Run())
+}
+
+type testLogKey int
+
+const (
+	testLogKeyHello testLogKey = iota
+)
+
+func (k testLogKey) String() string {
+	switch k {
+	case testLogKeyHello:
+		return "hello"
+	}
+	panic("unkown testLogKey")
+}
 
 const (
 	serverName  = "box-head-us"
@@ -77,4 +97,14 @@ func TestContextIDLog(t *testing.T) {
 	ctx.Info("no storage driver")
 	ctx = WithValue(ctx, DriverKey, &driver{})
 	ctx.Info("storage driver set")
+}
+
+func TestContextIDLogCustomLoggerKey(t *testing.T) {
+	ctx := WithValue(Background(), ServerKey, &server{})
+	ctx.Info("no storage driver")
+	ctx = WithValue(ctx, DriverKey, &driver{})
+	ctx.Info("storage driver set")
+
+	ctx = ctx.WithValue(testLogKeyHello, "world")
+	ctx.Info("testing custom log keys")
 }


### PR DESCRIPTION
This patch enables the ability to register custom context keys that will be automatically checked when providing HTTP headers to HTTP requests and during the creation of a context log entry's fields collection.

For examples on how to register custom keys see the `./api/client/client_http.go` and `./api/context/contex_test.go` sources.

A simple example would be:

```
import "github.com/emccode/libstorage/api/context"

// PollyHeaderKey is the type for Polly HTTP header keys.
type PollyHeaderKey int

const (
    // RequestPathHeaderKey is the header key for the Polly-Requestpath header.
    RequestPathHeaderKey PollyHeaderKey = iota
)

func (k PollyHeaderKey) String() string {
    switch k {
    case RequestPathHeaderKey:
        return "Polly-Requestpath"
    }
}

func init() {
    context.RegisterCustomKey(RequestPathHeaderKey, context.CustomHeaderKey)
}

func main() {
    ctx := context.Background()
    ctx = ctx.WithValue(RequestPathHeaderKey, "admin")
}
```

The above example would result in all outgoing HTTP requests sent from the libStorage client having a headers collection that includes:

```
Polly-Requestpath: admin
```

@clintonskitson, for what it's worth, `requestPath` is not a valid header name according to [industry standards](http://stackoverflow.com/questions/3561381/custom-http-headers-naming-conventions) regarding custom headers. To that end the header name should be `Polly-Requestpath`. 

Now, you may be wondering why not `Polly-RequestPath`, and that's a great question. The answer is because I said so...j/k. The answer is because of Golang's header name canonicalization process. No matter how a header name is provided, it is stored (and must be read) using the casing syntax prescribed by [Golang's `http.CanonicalHeaderKey` function](https://golang.org/pkg/net/http/#CanonicalHeaderKey).

That's why the libStorage headers aren't `libStorage-InstanceID` and are instead `Libstorage-Instanceid`.

(re: #134)