### PR TITLE
Bugfix for lss-$GOOS, logging, unix sock, etc.

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/akutz/gofig"
 
+	"github.com/emccode/libstorage/api/types"
+
 	// imported to load routers
 	_ "github.com/emccode/libstorage/imports/routers"
 
@@ -58,7 +60,7 @@ func Run(host string, tls bool, driversAndServices ...string) error {
 // Kill signal is received by the owner process or the server returns an error
 // via its error channel.
 func Start(host string, tls bool, driversAndServices ...string) (
-	gofig.Config, io.Closer, error, <-chan error) {
+	gofig.Config, types.Server, error, <-chan error) {
 
 	if runHost := os.Getenv("LIBSTORAGE_RUN_HOST"); runHost != "" {
 		host = runHost
@@ -86,6 +88,6 @@ func RunWithConfig(config gofig.Config) error {
 // StartWithConfig starts the server by specifying a configuration object and
 // returns a channel when errors occur runs until a Kill signal is received
 // by the owner process or the server returns an error via its error channel.
-func StartWithConfig(config gofig.Config) (io.Closer, error, <-chan error) {
+func StartWithConfig(config gofig.Config) (types.Server, error, <-chan error) {
 	return startWithConfig(config)
 }

--- a/api/types/types_config.go
+++ b/api/types/types_config.go
@@ -58,6 +58,9 @@ const (
 	// ConfigServices is a config key.
 	ConfigServices = ConfigServer + ".services"
 
+	// ConfigServerAutoEndpointMode is a config key.
+	ConfigServerAutoEndpointMode = ConfigServer + ".autoEndpointMode"
+
 	// ConfigEndpoints is a config key.
 	ConfigEndpoints = ConfigServer + ".endpoints"
 

--- a/api/types/types_server.go
+++ b/api/types/types_server.go
@@ -1,7 +1,10 @@
 package types
 
+import "io"
+
 // Server is the interface for a libStorage server.
 type Server interface {
+	io.Closer
 
 	// Name returns the name of the server.
 	Name() string

--- a/api/utils/utils.go
+++ b/api/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	_ "github.com/akutz/golf"
+	"github.com/emccode/libstorage/api/utils/paths"
 )
 
 // GetTypePkgPathAndName gets ths type and package path of the provided
@@ -27,7 +28,7 @@ func GetTypePkgPathAndName(i interface{}) string {
 
 // GetTempSockFile returns a new sock file in a temp space.
 func GetTempSockFile() string {
-	f, err := ioutil.TempFile("", "")
+	f, err := ioutil.TempFile(paths.Run.String(), "")
 	if err != nil {
 		panic(err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	log "github.com/Sirupsen/logrus"
 	"github.com/akutz/gofig"
 
 	"github.com/emccode/libstorage/api/context"
@@ -43,6 +44,12 @@ func New(config gofig.Config) (types.Client, error) {
 
 	c = &client{ctx: context.Background(), config: config}
 	c.ctx = c.ctx.WithValue(context.ClientKey, c)
+
+	// always update the server context's log level
+	if lvl, err := log.ParseLevel(
+		config.GetString(types.ConfigLogLevel)); err == nil {
+		context.SetLogLevel(c.ctx, lvl)
+	}
 
 	if config.IsSet(types.ConfigService) {
 		c.ctx = c.ctx.WithValue(

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 16c0dc20aeee51fe83c1886d99725d468e012571bb715dd21e13d105181de208
-updated: 2016-05-15T17:00:33.967583462-05:00
+updated: 2016-05-18T20:12:48.384193609-05:00
 imports:
 - name: github.com/akutz/gofig
   version: 84e1fb25c0a0fd2f2da6d7ce7827881f7c80eef5
@@ -16,7 +16,7 @@ imports:
   - vboxwebsrv
   - virtualboxclient
 - name: github.com/asaskevich/govalidator
-  version: 37d5f827499d1c346df42f2ad7fcb7f453833a57
+  version: 68c9ffa338c6d71d29c643a61862909d2db75b28
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/BurntSushi/toml
@@ -83,12 +83,12 @@ imports:
   subpackages:
   - assert
 - name: golang.org/x/net
-  version: ef00b378c73f107bf44d5c9b69875255ce89b79a
+  version: 8aacbecd63e105fa5f07afbd49472fd3e17a19d1
   subpackages:
   - context/ctxhttp
   - context
 - name: golang.org/x/sys
-  version: f78f5183ff267d751d0af20bbe59158f3e4cd53e
+  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
   subpackages:
   - unix
 - name: gopkg.in/fsnotify.v1

--- a/imports/config/imports_config.go
+++ b/imports/config/imports_config.go
@@ -49,6 +49,7 @@ func init() {
 		r.Key(keyType, "", defaultVal, description, args...)
 	}
 
+	rk(gofig.String, "unix", "", types.ConfigServerAutoEndpointMode)
 	rk(gofig.String, "", "", types.ConfigHost)
 	rk(gofig.String, "", "", types.ConfigService)
 	rk(gofig.String, runtime.GOOS, "", types.ConfigOSDriver)

--- a/libstorage.go
+++ b/libstorage.go
@@ -36,7 +36,6 @@ package libstorage
 import (
 	"bytes"
 	"fmt"
-	"io"
 
 	"github.com/akutz/gofig"
 
@@ -74,7 +73,7 @@ If the config parameter is nil a default instance is created. The
 libStorage service is served at the address specified by the configuration
 property libstorage.host.
 */
-func Serve(config gofig.Config) (io.Closer, error, <-chan error) {
+func Serve(config gofig.Config) (types.Server, error, <-chan error) {
 	return server.Serve(config)
 }
 
@@ -96,13 +95,14 @@ func Dial(config gofig.Config) (types.Client, error) {
 // While a new server may be launched, it's still up to the caller to provide
 // a config instance with the correct properties to specify service
 // information for a libStorage server.
-func New(config gofig.Config) (types.Client, io.Closer, error, <-chan error) {
+func New(
+	config gofig.Config) (types.Client, types.Server, error, <-chan error) {
 
 	var (
 		h       = config.GetString(types.ConfigHost)
 		em      = config.GetBool(types.ConfigEmbedded)
 		c       types.Client
-		s       io.Closer
+		s       types.Server
 		err     error
 		errs    <-chan error
 		serving bool


### PR DESCRIPTION
This patch fixes several outstanding issues and introduces one new feature called autoEndpointMode:

  - The `lss-$GOOS` reference server implementation now ignores all other command line input if a configuration file is specified

  - The `libstorage.logging.level` value is now respected and both the client's and server's root contexts read this value in order to initialize the root contexts from which all client and server contexts derive with the configured log level.

  - Server endpoints configured to use UNIX sockets now have said sockets created in `$LIBSTORAGE_HOME/var/run/libstorage`.

  - The `libstorage.host` property will be used to create a default endpoint for the server if no endpoints are defined.

  - A new property, `libstorage.server.autoEndpointMode`, which defaults to `unix` and can also be set to `tcp`, is used to determine what type of endpoint to create as "localhost" if no endpoints are explicitly defined.

  - The `Server` interface is now returned from the server package instead of `io.Closer`. The `Server` interface can be used to get the name of the server, close the server, and also get all configured endpoint addresses for the server.