### PR TITLE
Config Enhancements

### DIFF
--- a/api/server/server_http.go
+++ b/api/server/server_http.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/akutz/gofig"
 	"github.com/akutz/goof"
 	"github.com/akutz/gotil"
 	"github.com/gorilla/mux"
@@ -115,7 +114,7 @@ func (s *server) initEndpoints(ctx types.Context) error {
 		}
 
 		tlsConfig, err :=
-			utils.ParseTLSConfig(s.config.Scope(endpoint), logFields)
+			utils.ParseTLSConfig(s.config.Scope(endpoint), logFields, endpoint)
 		if err != nil {
 			return err
 		}
@@ -279,9 +278,9 @@ func (s *HTTPServer) Context() types.Context {
 	return s.ctx
 }
 
-func getLogIO(propName string, config gofig.Config) io.WriteCloser {
+func getLogIO(path, propName string) io.WriteCloser {
 
-	if path := config.GetString(propName); path != "" {
+	if path != "" {
 		logio, err := os.OpenFile(
 			path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {

--- a/api/types/types_config.go
+++ b/api/types/types_config.go
@@ -31,20 +31,23 @@ const (
 	// ConfigIntegrationDriver is a config key.
 	ConfigIntegrationDriver = ConfigRoot + ".integration.driver"
 
+	// ConfigLogging is a config key.
+	ConfigLogging = ConfigRoot + ".logging"
+
 	// ConfigLogLevel is a config key.
-	ConfigLogLevel = ConfigRoot + ".logging.level"
+	ConfigLogLevel = ConfigLogging + ".level"
 
 	// ConfigLogStdout is a config key.
-	ConfigLogStdout = ConfigRoot + ".logging.stdout"
+	ConfigLogStdout = ConfigLogging + ".stdout"
 
 	// ConfigLogStderr is a config key.
-	ConfigLogStderr = ConfigRoot + ".logging.stderr"
+	ConfigLogStderr = ConfigLogging + ".stderr"
 
 	// ConfigLogHTTPRequests is a config key.
-	ConfigLogHTTPRequests = ConfigRoot + ".logging.httpRequests"
+	ConfigLogHTTPRequests = ConfigLogging + ".httpRequests"
 
 	// ConfigLogHTTPResponses is a config key.
-	ConfigLogHTTPResponses = ConfigRoot + ".logging.httpResponses"
+	ConfigLogHTTPResponses = ConfigLogging + ".httpResponses"
 
 	// ConfigHTTPDisableKeepAlive is a config key.
 	ConfigHTTPDisableKeepAlive = ConfigRoot + ".http.disableKeepAlive"

--- a/api/utils/utils_config.go
+++ b/api/utils/utils_config.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/akutz/gofig"
+)
+
+func isSet(
+	config gofig.Config,
+	key string,
+	roots ...string) bool {
+
+	for _, r := range roots {
+		rk := strings.Replace(key, "libstorage.", fmt.Sprintf("%s.", r), 1)
+		if config.IsSet(rk) {
+			return true
+		}
+	}
+
+	if config.IsSet(key) {
+		return true
+	}
+
+	return false
+}
+
+func getString(
+	config gofig.Config,
+	key string,
+	roots ...string) string {
+
+	var val string
+
+	for _, r := range roots {
+		rk := strings.Replace(key, "libstorage.", fmt.Sprintf("%s.", r), 1)
+		if val = config.GetString(rk); val != "" {
+			return val
+		}
+	}
+
+	val = config.GetString(key)
+	if val != "" {
+		return val
+	}
+
+	return ""
+}
+
+func getBool(
+	config gofig.Config,
+	key string,
+	roots ...string) bool {
+
+	for _, r := range roots {
+		rk := strings.Replace(key, "libstorage.", fmt.Sprintf("%s.", r), 1)
+		if config.IsSet(rk) {
+			return config.GetBool(rk)
+		}
+	}
+
+	if config.IsSet(key) {
+		return config.GetBool(key)
+	}
+
+	return false
+}

--- a/api/utils/utils_logging.go
+++ b/api/utils/utils_logging.go
@@ -1,0 +1,76 @@
+package utils
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/akutz/gofig"
+	"github.com/emccode/libstorage/api/types"
+)
+
+// LoggingConfig is the logging configuration.
+type LoggingConfig struct {
+
+	// Level is the log level.
+	Level log.Level
+
+	// Stdout is the path to the file to which to log stdout.
+	Stdout string
+
+	// Stderr is the path to the file to which to log stderr.
+	Stderr string
+
+	// HTTPRequests is a flag indicating whether or not to log HTTP requests.
+	HTTPRequests bool
+
+	// HTTPResponses is a flag indicating whether or not to log HTTP responses.
+	HTTPResponses bool
+}
+
+// ParseLoggingConfig returns a new LoggingConfig instance.
+func ParseLoggingConfig(
+	config gofig.Config,
+	fields log.Fields,
+	roots ...string) (*LoggingConfig, error) {
+
+	f := func(k string, v interface{}) {
+		if fields == nil {
+			return
+		}
+		fields[k] = v
+	}
+
+	logConfig := &LoggingConfig{
+		Level: log.WarnLevel,
+	}
+
+	if lvl, err := log.ParseLevel(
+		getString(config, types.ConfigLogLevel, roots...)); err == nil {
+		logConfig.Level = lvl
+		f(types.ConfigLogLevel, lvl)
+	}
+
+	stdOutPath := getString(config, types.ConfigLogStdout, roots...)
+	if stdOutPath != "" {
+		logConfig.Stdout = stdOutPath
+		f(types.ConfigLogStdout, stdOutPath)
+	}
+
+	stdErrPath := getString(config, types.ConfigLogStderr, roots...)
+	if stdErrPath != "" {
+		logConfig.Stderr = stdErrPath
+		f(types.ConfigLogStderr, stdErrPath)
+	}
+
+	if isSet(config, types.ConfigLogHTTPRequests, roots...) {
+		logConfig.HTTPRequests = getBool(
+			config, types.ConfigLogHTTPRequests, roots...)
+		f(types.ConfigLogHTTPRequests, logConfig.HTTPRequests)
+	}
+
+	if isSet(config, types.ConfigLogHTTPResponses, roots...) {
+		logConfig.HTTPResponses = getBool(
+			config, types.ConfigLogHTTPResponses, roots...)
+		f(types.ConfigLogHTTPResponses, logConfig.HTTPResponses)
+	}
+
+	return logConfig, nil
+}

--- a/drivers/storage/libstorage/libstorage_driver.go
+++ b/drivers/storage/libstorage/libstorage_driver.go
@@ -48,7 +48,8 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 		return err
 	}
 
-	tlsConfig, err := utils.ParseTLSConfig(config, logFields)
+	tlsConfig, err := utils.ParseTLSConfig(
+		config, logFields, "libstorage.client")
 	if err != nil {
 		return err
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 16c0dc20aeee51fe83c1886d99725d468e012571bb715dd21e13d105181de208
-updated: 2016-05-18T20:12:48.384193609-05:00
+updated: 2016-05-19T00:48:53.231195713-05:00
 imports:
 - name: github.com/akutz/gofig
   version: 84e1fb25c0a0fd2f2da6d7ce7827881f7c80eef5
@@ -83,7 +83,7 @@ imports:
   subpackages:
   - assert
 - name: golang.org/x/net
-  version: 8aacbecd63e105fa5f07afbd49472fd3e17a19d1
+  version: 5916dcb167ed985a5b9e6871fbfd74848a4c170b
   subpackages:
   - context/ctxhttp
   - context


### PR DESCRIPTION
This patch updates the config logic so that all variations of `libstorage.client|server.logging|tls` are checked for the `libstorage.logging` and `libstorage.tls` properties in order to make configuring libStorage as simple for the user as possible.

For example, the following is no longer necessary. It works, but it isn't required:

```yaml
libstorage:
  client:
    libstorage:
      logging:
        level: info
```

Instead, whenever the `libstorage.logging` and `libstorage.tls` property keys are accessed via the `utils.ParseTLSConfig` and `utils.ParseLoggingConfig` functions, the keys are first checked against the true paths and then also checked against those paths if they were injected with `.server` or `.client`. For example, if `libstorage.logging.level` doesn't exist, the function would check for `libstorage.server.logging.level`.

This enhancement simplifies the above configuration so that it can look like this:

 ```yaml
libstorage:
  client:
    logging:
      level: info
```