### PR TITLE
Version Info & Time in Logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ cli/semaphores/open
 cli/semaphores/wait
 cli/semaphores/signal
 cli/semaphores/unlink
+api/api_generated.go
 api/server/executors/executors_generated.go
 
 # Created by https://www.gitignore.io

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-all: build
+all:
+	$(MAKE) deps
+	$(MAKE) build
 
 ################################################################################
 ##                                 CONSTANTS                                  ##
@@ -238,6 +240,142 @@ endif
 $(GO_BINDATA):
 	go install $(GO_BINDATA_IMPORT_PATH)
 GO_DEPS += $(GO_BINDATA)
+
+################################################################################
+##                                  VERSION                                   ##
+################################################################################
+
+# parse a semver
+SEMVER_PATT := ^[^\d]*(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z].+?))?(?:-(\d+)-g(.+?)(?:-(dirty))?)?$$
+PARSE_SEMVER = $(shell echo $(1) | perl -pe 's/$(SEMVER_PATT)/$(2)/gim')
+
+# describe the git information and create a parsing function for it
+GIT_DESCRIBE := $(shell git describe --long --dirty)
+PARSE_GIT_DESCRIBE = $(call PARSE_SEMVER,$(GIT_DESCRIBE),$(1))
+
+# parse the version components from the git information
+V_MAJOR := $(call PARSE_GIT_DESCRIBE,$$1)
+V_MINOR := $(call PARSE_GIT_DESCRIBE,$$2)
+V_PATCH := $(call PARSE_GIT_DESCRIBE,$$3)
+V_NOTES := $(call PARSE_GIT_DESCRIBE,$$4)
+V_BUILD := $(call PARSE_GIT_DESCRIBE,$$5)
+V_SHA_SHORT := $(call PARSE_GIT_DESCRIBE,$$6)
+V_DIRTY := $(call PARSE_GIT_DESCRIBE,$$7)
+
+# the version's binary os and architecture type
+ifeq ($(GOOS),windows)
+	V_OS := Windows_NT
+endif
+ifeq ($(GOOS),linux)
+	V_OS := Linux
+endif
+ifeq ($(GOOS),darwin)
+	V_OS := Darwin
+endif
+ifeq ($(GOARCH),386)
+	V_ARCH := i386
+endif
+ifeq ($(GOARCH),amd64)
+	V_ARCH := x86_64
+endif
+V_OS_ARCH := $(V_OS)-$(V_ARCH)
+
+# the long commit hash
+V_SHA_LONG := $(shell git show HEAD -s --format=%H)
+
+# the branch name, possibly from travis-ci
+ifeq ($(origin TRAVIS_BRANCH), undefined)
+	TRAVIS_BRANCH := $(shell git branch | grep '*' | awk '{print $$2}')
+else
+	ifeq ($(strip $(TRAVIS_BRANCH)),)
+		TRAVIS_BRANCH := $(shell git branch | grep '*' | awk '{print $$2}')
+	endif
+endif
+ifeq ($(origin TRAVIS_TAG), undefined)
+	TRAVIS_TAG := $(TRAVIS_BRANCH)
+else
+	ifeq ($(strip $(TRAVIS_TAG)),)
+		TRAVIS_TAG := $(TRAVIS_BRANCH)
+	endif
+endif
+V_BRANCH := $(TRAVIS_TAG)
+
+# the build date as an epoch
+V_EPOCH := $(shell date +%s)
+
+# the build date
+V_BUILD_DATE := $(shell perl -e 'use POSIX strftime; print strftime("%a, %d %b %Y %H:%M:%S %Z", localtime($(V_EPOCH)))')
+
+# the release date as required by bintray
+V_RELEASE_DATE := $(shell perl -e 'use POSIX strftime; print strftime("%Y-%m-%d", localtime($(V_EPOCH)))')
+
+# init the semver
+V_SEMVER := $(V_MAJOR).$(V_MINOR).$(V_PATCH)
+ifneq ($(V_NOTES),)
+	V_SEMVER := $(V_SEMVER)-$(V_NOTES)
+endif
+
+# get the version file's version
+V_FILE := $(strip $(shell cat VERSION 2> /dev/null))
+
+# append the build number and dirty values to the semver if appropriate
+ifneq ($(V_BUILD),)
+	ifneq ($(V_BUILD),0)
+		# if the version file's version is different than the version parsed from the
+		# git describe information then use the version file's version
+		ifneq ($(V_SEMVER),$(V_FILE))
+			V_MAJOR := $(call PARSE_SEMVER,$(V_FILE),$$1)
+			V_MINOR := $(call PARSE_SEMVER,$(V_FILE),$$2)
+			V_PATCH := $(call PARSE_SEMVER,$(V_FILE),$$3)
+			V_NOTES := $(call PARSE_SEMVER,$(V_FILE),$$4)
+			V_SEMVER := $(V_MAJOR).$(V_MINOR).$(V_PATCH)
+			ifneq ($(V_NOTES),)
+				V_SEMVER := $(V_SEMVER)-$(V_NOTES)
+			endif
+		endif
+		V_SEMVER := $(V_SEMVER)+$(V_BUILD)
+	endif
+endif
+ifeq ($(V_DIRTY),dirty)
+	V_SEMVER := $(V_SEMVER)+$(V_DIRTY)
+endif
+
+define API_GENERATED_CONTENT
+package api
+
+import (
+	"time"
+
+	"github.com/emccode/libstorage/api/types"
+)
+
+func init() {
+	Version = &types.VersionInfo{}
+	Version.Arch = "$(V_OS_ARCH)"
+	Version.Branch = "$(V_BRANCH)"
+	Version.BuildTimestamp = time.Unix($(V_EPOCH), 0)
+	Version.SemVer = "$(V_SEMVER)"
+	Version.ShaLong = "$(V_SHA_LONG)"
+}
+
+endef
+
+API_GENERATED_SRC := ./api/api_generated.go
+$(API_GENERATED_SRC):
+	$(file >$@,$(API_GENERATED_CONTENT))
+GO_PHONY += $(API_GENERATED_SRC)
+
+API_A := $(GOPATH)/pkg/$(GOOS)_$(GOARCH)/$(ROOT_IMPORT_PATH)/api.a
+$(API_A): $(API_GENERATED_SRC)
+
+version:
+	@echo SemVer: $(V_SEMVER)
+	@echo Binary: $(V_OS_ARCH)
+	@echo Branch: $(V_BRANCH)
+	@echo Commit: $(V_SHA_LONG)
+	@echo Formed: $(V_BUILD_DATE)
+
+GO_PHONY += version
 
 ################################################################################
 ##                               PROJECT BUILD                                ##

--- a/api/api.go
+++ b/api/api.go
@@ -1,13 +1,10 @@
 package api
 
-import (
-	"github.com/blang/semver"
-)
+import "github.com/emccode/libstorage/api/types"
 
 var (
 	// Version of the current REST API
-	Version = semver.MustParse("1.0.0")
-
-	// MinVersion represents Minimun REST API version supported
-	MinVersion = semver.MustParse("1.0.0")
+	Version *types.VersionInfo
 )
+
+//go:generate make -C ../ ./api/api_generated.go

--- a/api/context/context_logger.go
+++ b/api/context/context_logger.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"fmt"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -14,7 +15,9 @@ const (
 
 func (ctx *lsc) ctxFields() map[string]interface{} {
 
-	fields := map[string]interface{}{}
+	fields := map[string]interface{}{
+		"time": time.Now().UTC().Unix(),
+	}
 
 	for key := Key(keyLoggable - 1); key > keyEOF; key-- {
 		ctxFieldsProcessValue(key.String(), ctx.Value(key), fields)

--- a/api/server/httputils/httputils_route.go
+++ b/api/server/httputils/httputils_route.go
@@ -14,6 +14,10 @@ type route struct {
 	middlewares []types.Middleware
 }
 
+func (r *route) ContextLoggerField() (string, interface{}) {
+	return "route", r.name
+}
+
 // Method specifies the method for the route.
 func (r *route) Method(method string) types.Route {
 	r.method = method

--- a/api/server/router/root/root_router.go
+++ b/api/server/router/root/root_router.go
@@ -30,6 +30,7 @@ func (r *router) root(
 		fmt.Sprintf("%s/services", rootURL),
 		fmt.Sprintf("%s/snapshots", rootURL),
 		fmt.Sprintf("%s/tasks", rootURL),
+		fmt.Sprintf("%s/version", rootURL),
 		fmt.Sprintf("%s/volumes", rootURL),
 	}
 

--- a/api/server/router/router.go
+++ b/api/server/router/router.go
@@ -7,5 +7,6 @@ import (
 	_ "github.com/emccode/libstorage/api/server/router/service"
 	_ "github.com/emccode/libstorage/api/server/router/snapshot"
 	_ "github.com/emccode/libstorage/api/server/router/tasks"
+	_ "github.com/emccode/libstorage/api/server/router/version"
 	_ "github.com/emccode/libstorage/api/server/router/volume"
 )

--- a/api/server/router/version/version.go
+++ b/api/server/router/version/version.go
@@ -1,0 +1,37 @@
+package version
+
+import (
+	"github.com/akutz/gofig"
+
+	"github.com/emccode/libstorage/api/registry"
+	"github.com/emccode/libstorage/api/server/httputils"
+	"github.com/emccode/libstorage/api/types"
+)
+
+func init() {
+	registry.RegisterRouter(&router{})
+}
+
+type router struct {
+	routes []types.Route
+}
+
+func (r *router) Name() string {
+	return "version-router"
+}
+
+func (r *router) Init(config gofig.Config) {
+	r.initRoutes()
+}
+
+// Routes returns the available routes.
+func (r *router) Routes() []types.Route {
+	return r.routes
+}
+
+func (r *router) initRoutes() {
+	r.routes = []types.Route{
+		// GET
+		httputils.NewGetRoute("version", "/version", r.versionInspect),
+	}
+}

--- a/api/server/router/version/version_router.go
+++ b/api/server/router/version/version_router.go
@@ -1,0 +1,19 @@
+package version
+
+import (
+	"net/http"
+
+	"github.com/emccode/libstorage/api"
+	"github.com/emccode/libstorage/api/server/httputils"
+	"github.com/emccode/libstorage/api/types"
+)
+
+func (r *router) versionInspect(
+	ctx types.Context,
+	w http.ResponseWriter,
+	req *http.Request,
+	store types.Store) error {
+
+	httputils.WriteJSON(w, http.StatusOK, api.Version)
+	return nil
+}

--- a/api/server/server_http.go
+++ b/api/server/server_http.go
@@ -170,7 +170,7 @@ func (s *server) makeHTTPHandler(
 			}
 		}
 
-		ctx.Debug("http request")
+		ctx.Info("http request")
 
 		vars := mux.Vars(req)
 		if vars == nil {

--- a/api/tests/tests_std.go
+++ b/api/tests/tests_std.go
@@ -18,7 +18,7 @@ var TestRoot = func(config gofig.Config, client types.Client, t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(reply), 5)
+	assert.Equal(t, len(reply), 6)
 }
 
 // InstanceIDTest is the test harness for testing the instance ID.

--- a/api/types/types_version.go
+++ b/api/types/types_version.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// VersionInfo provides information about the libStorage version.
+type VersionInfo struct {
+
+	// SemVer is the semantic version string
+	SemVer string
+
+	// ShaLong is the commit hash from which this package was built
+	ShaLong string
+
+	// BuildTimestamp is the UTC timestamp for when this package was built.
+	BuildTimestamp time.Time
+
+	// Branch is the branch name from which this package was built
+	Branch string
+
+	// Arch is the OS-Arch string of the system on which this package is
+	// supported.
+	Arch string
+}
+
+// String returns the version information as a string.
+func (v *VersionInfo) String() string {
+	buf := &bytes.Buffer{}
+	fmt.Fprintf(buf, "SemVer: %s\n", v.SemVer)
+	fmt.Fprintf(buf, "OsArch: %s\n", v.Arch)
+	fmt.Fprintf(buf, "Branch: %s\n", v.Branch)
+	fmt.Fprintf(buf, "Commit: %s\n", v.ShaLong)
+	fmt.Fprintf(buf, "Formed: %s\n", v.BuildTimestamp.Format(time.RFC1123))
+	return buf.String()
+}
+
+// MarshalJSON returns the JSON representation of the version.
+func (v *VersionInfo) MarshalJSON() ([]byte, error) {
+
+	ver := &struct {
+		SemVer         string `json:"semver"`
+		ShaLong        string `json:"shaLong"`
+		BuildTimestamp int64  `json:"buildTimestamp"`
+		Branch         string `json:"branch"`
+		Arch           string `json:"arch"`
+	}{
+		SemVer:         v.SemVer,
+		ShaLong:        v.ShaLong,
+		BuildTimestamp: v.BuildTimestamp.Unix(),
+		Branch:         v.Branch,
+		Arch:           v.Arch,
+	}
+
+	return json.Marshal(ver)
+}

--- a/cli/lss/lss.go
+++ b/cli/lss/lss.go
@@ -10,6 +10,7 @@ import (
 	"github.com/akutz/gotil"
 	flag "github.com/spf13/pflag"
 
+	"github.com/emccode/libstorage/api"
 	"github.com/emccode/libstorage/api/server"
 	apitypes "github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/utils"
@@ -28,6 +29,7 @@ var (
 	flagLogLvl  *string
 	flagHelp    *bool
 	flagVerbose *bool
+	flagVersion *bool
 	config      gofig.Config
 )
 
@@ -37,6 +39,7 @@ func init() {
 	flagHost = cliFlags.StringP("host", "h", "", "<proto>://<addr>")
 	flagLogLvl = cliFlags.StringP("log", "l", "info", "error|warn|info|debug")
 	flagHelp = cliFlags.BoolP("help", "?", false, "print usage")
+	flagVersion = cliFlags.Bool("version", false, "print version info")
 	flagVerbose = cliFlags.BoolP("verbose", "v", false, "print verbose usage")
 	flag.CommandLine.AddFlagSet(cliFlags)
 }
@@ -47,6 +50,13 @@ func Run() {
 
 	flag.Usage = printUsage
 	flag.Parse()
+
+	if flagVersion != nil && *flagVersion {
+		_, _, thisExeAbsPath := gotil.GetThisPathParts()
+		fmt.Fprintf(os.Stdout, "Binary: %s\n", thisExeAbsPath)
+		fmt.Fprint(os.Stdout, api.Version.String())
+		os.Exit(0)
+	}
 
 	// if a config is specified then do not care about any other options
 	if flagConfig != nil && gotil.FileExists(*flagConfig) {
@@ -134,6 +144,7 @@ func Run() {
 func printUsage() {
 	fmt.Fprintf(os.Stderr, "usage: %s [-options] ", os.Args[0])
 	fmt.Fprintf(os.Stderr, "-c,--config <configFilePath>")
+	fmt.Fprintf(os.Stderr, "--version")
 	fmt.Fprintf(os.Stderr, "<driver>[:<service>] [<driver>[:<service>]...]")
 	fmt.Fprintf(os.Stderr, "\n\n")
 

--- a/imports/routers/imports_routers.go
+++ b/imports/routers/imports_routers.go
@@ -7,5 +7,6 @@ import (
 	_ "github.com/emccode/libstorage/api/server/router/service"
 	_ "github.com/emccode/libstorage/api/server/router/snapshot"
 	_ "github.com/emccode/libstorage/api/server/router/tasks"
+	_ "github.com/emccode/libstorage/api/server/router/version"
 	_ "github.com/emccode/libstorage/api/server/router/volume"
 )


### PR DESCRIPTION
This patch adds a new resource to the libStorage root resources, `/version`. The /version resource returns the version information for the libStorage server. For example:

```json
  {
    "semver": "0.1.0+5+dirty",
    "shaLong": "9a4c28adb385281f1b053032e6fefb77f597b7cf",
    "buildTimestamp": 1463666979,
    "branch": "feature/version",
    "arch": "Darwin-x86_64"
  }
```

In addition, the version information is also available to the reference server binary, `lss-$GOOS`. For example:

```shell
  $ lss-darwin --version
  Binary: /Users/akutz/Projects/go/bin/lss-darwin
  SemVer: 0.1.0+5+dirty
  OsArch: Darwin-x86_64
  Branch: feature/version
  Commit: 9a4c28adb385281f1b053032e6fefb77f597b7cf
  Formed: Thu, 19 May 2016 09:09:39 CDT
```

Finally, this patch also adds the field `time` to all context-emitted log messages so that every entry includes `time=EPOCH` to indicate at what time the log entry was created.