### PR TITLE
Fix for LocalDevice Header Error

### DIFF
--- a/api/server/handlers/handlers_local_devices.go
+++ b/api/server/handlers/handlers_local_devices.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/emccode/libstorage/api/context"
@@ -28,10 +27,6 @@ func (h *localDevicesHandler) Name() string {
 func (h *localDevicesHandler) Handler(m types.APIFunc) types.APIFunc {
 	return (&localDevicesHandler{m}).Handle
 }
-
-var (
-	locDevRX = regexp.MustCompile(`^(.+?)=((?:(?:.+?)=(?:.+?)(?:,\s*)?)+)$`)
-)
 
 // Handle is the type's Handler function.
 func (h *localDevicesHandler) Handle(

--- a/api/types/types_instanceid_test.go
+++ b/api/types/types_instanceid_test.go
@@ -128,3 +128,9 @@ func TestInstanceIDMetadata(t *testing.T) {
 	expectedBuf, _ := json.Marshal(newMetadata())
 	assert.Equal(t, string(expectedBuf), string(actualBuf))
 }
+
+func TestInstanceIDUnmarshalText(t *testing.T) {
+	iid := &InstanceID{}
+	err := iid.UnmarshalText([]byte("scaleio="))
+	assert.NoError(t, err)
+}

--- a/api/types/types_localdevices.go
+++ b/api/types/types_localdevices.go
@@ -61,7 +61,7 @@ func (l *LocalDevices) MarshalText() ([]byte, error) {
 }
 
 var (
-	ldRX         = regexp.MustCompile(`^(.+?)=(\S+:\S+(?:(\s*,\s*\S+:\S+)*))$`)
+	ldRX         = regexp.MustCompile(`^(.+?)=(\S+:\S+(?:\s*,\s*\S+:\S+)*)?$`)
 	commaByteSep = []byte{','}
 	colonByteSep = []byte{':'}
 )

--- a/api/types/types_localdevices_test.go
+++ b/api/types/types_localdevices_test.go
@@ -30,6 +30,13 @@ func TestLocalDevicesMarshalText(t *testing.T) {
 	assert.EqualValues(t, ld1, ld2)
 }
 
+func TestLocalDevicesUnmarshalText(t *testing.T) {
+
+	ld1 := &LocalDevices{}
+	err := ld1.UnmarshalText([]byte("scaleio="))
+	assert.NoError(t, err)
+}
+
 func TestLocalDevicesMarshalJSON(t *testing.T) {
 
 	ld1 := newLocalDevicesObj()


### PR DESCRIPTION
This patch fixes issue #151 where an "Invalid LocalDevices" error is returned when a "Libstorage-Localdevices" header is provided that has a value of "DRIVER=" with no mapped volume data in the header. This should be considered a valid value, even if empty.