### PR TITLE
Client/LSX dependency fix

### DIFF
--- a/api/types/types_drivers_executor.go
+++ b/api/types/types_drivers_executor.go
@@ -11,6 +11,22 @@ import (
 type DeviceScanType int
 
 const (
+	// LSXCmdInstanceID is the command to execute to get the instance ID.
+	LSXCmdInstanceID = "instanceID"
+
+	// LSXCmdLocalDevices is the command to execute to get the local devices
+	// map.
+	LSXCmdLocalDevices = "localDevices"
+
+	// LSXCmdNextDevice is the command to execute to get the next device.
+	LSXCmdNextDevice = "nextDevice"
+
+	// LSXCmdWaitForDevice is the command to execute to wait until a device,
+	// identified by volume ID, is presented to the system.
+	LSXCmdWaitForDevice = "wait"
+)
+
+const (
 
 	// DeviceScanQuick performs a shallow, quick scan.
 	DeviceScanQuick DeviceScanType = iota

--- a/cli/lsx/lsx.go
+++ b/cli/lsx/lsx.go
@@ -21,21 +21,6 @@ import (
 	_ "github.com/emccode/libstorage/imports/executors"
 )
 
-const (
-	// InstanceID is the command to execute to get the instance ID.
-	InstanceID = "instanceID"
-
-	// LocalDevices is the command to execute to get the local devices map.
-	LocalDevices = "localDevices"
-
-	// NextDevice is the command to execute to get the next device.
-	NextDevice = "nextDevice"
-
-	// WaitForDevice is the command to execute to wait until a device,
-	// identified by volume ID, is presented to the system.
-	WaitForDevice = "wait"
-)
-
 var (
 	cmdRx = regexp.MustCompile(
 		`(?i)^instanceid|nextdevice|localdevices|wait$`)

--- a/drivers/storage/libstorage/libstorage_client_xcli.go
+++ b/drivers/storage/libstorage/libstorage_client_xcli.go
@@ -12,7 +12,6 @@ import (
 	"github.com/emccode/libstorage/api/context"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/utils/paths"
-	"github.com/emccode/libstorage/cli/lsx"
 )
 
 func (c *client) InstanceID(
@@ -36,7 +35,7 @@ func (c *client) InstanceID(
 	}
 	driverName := strings.ToLower(si.Driver.Name)
 
-	out, err := c.runExecutor(ctx, driverName, lsx.InstanceID)
+	out, err := c.runExecutor(ctx, driverName, types.LSXCmdInstanceID)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +79,7 @@ func (c *client) NextDevice(
 	}
 	driverName := si.Driver.Name
 
-	out, err := c.runExecutor(ctx, driverName, lsx.NextDevice)
+	out, err := c.runExecutor(ctx, driverName, types.LSXCmdNextDevice)
 	if err != nil {
 		return "", err
 	}
@@ -107,7 +106,7 @@ func (c *client) LocalDevices(
 	driverName := si.Driver.Name
 
 	out, err := c.runExecutor(
-		ctx, driverName, lsx.LocalDevices, opts.ScanType.String())
+		ctx, driverName, types.LSXCmdLocalDevices, opts.ScanType.String())
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +139,7 @@ func (c *client) WaitForDevice(
 
 	exitCode := 0
 	out, err := c.runExecutor(
-		ctx, driverName, lsx.WaitForDevice,
+		ctx, driverName, types.LSXCmdWaitForDevice,
 		opts.ScanType.String(), opts.Token, opts.Timeout.String())
 	if exitError, ok := err.(*exec.ExitError); ok {
 		exitCode = exitError.Sys().(syscall.WaitStatus).ExitStatus()


### PR DESCRIPTION
This patch fixes the libStorage client's dependency tree so that it no longer depends upon the libStorage executor or its transitive dependencies.