### PR TITLE
Bugfix for Executor Stdout Logging

### DIFF
--- a/drivers/storage/libstorage/libstorage_client_xcli.go
+++ b/drivers/storage/libstorage/libstorage_client_xcli.go
@@ -184,6 +184,5 @@ func (c *client) runExecutor(
 		cmd.Env = append(cmd.Env, cev)
 	}
 
-	out, err := cmd.CombinedOutput()
-	return out, err
+	return cmd.Output()
 }


### PR DESCRIPTION
This patch fixes an issue where the XCLI harness responsible for calling the executor binary was capturing combined Stdout & Stderr streams. As it turns out, Logrus emits all log messages on the Stderr stream, so if logging was verbose, it interrupted the logic for capturing the executor result. Now the XCLI harness only looks at the Stdout stream.