### PR TITLE
Fix for Gopkg HTTP URL matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ go:
   - 1.6
 go_import_path: github.com/emccode/libstorage
 before_install:
+  - git config --global 'url.https://gopkg.in/yaml.v1.insteadof' 'https://gopkg.in/yaml.v1/'
+  - git config --global 'url.https://gopkg.in/yaml.v2.insteadof' 'https://gopkg.in/yaml.v2/'
+  - git config --global 'url.https://gopkg.in/fsnotify.v1.insteadof' 'https://gopkg.in/fsnotify.v1/'
   - git config --global 'url.https://github.com/.insteadof' 'git://github.com/'
   - git config --global 'url.https://github.com/.insteadof' 'git@github.com:'
 install:


### PR DESCRIPTION
This patch fixes the issue with Gopkg go get attempts failing thanks to go get adding a trailing slash.