### PR TITLE
Add Context to Server & Client New

### DIFF
--- a/api/context/context.go
+++ b/api/context/context.go
@@ -38,17 +38,33 @@ func (ctx *lsc) rightSide() context.Context {
 	return ctx.right
 }
 
+// New returns a new context with the provided parent.
+func New(parent context.Context) types.Context {
+
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	var ctx types.Context = newContext(parent, nil, nil)
+
+	_, ok := ctx.Value(LoggerKey).(*log.Logger)
+	if !ok {
+		ctx = ctx.WithValue(LoggerKey,
+			&log.Logger{
+				Formatter: log.StandardLogger().Formatter,
+				Out:       log.StandardLogger().Out,
+				Hooks:     log.StandardLogger().Hooks,
+				Level:     log.StandardLogger().Level,
+			},
+		)
+	}
+
+	return ctx
+}
+
 // Background returns a new context with logging capabilities.
 func Background() types.Context {
-	ctx := newContext(context.Background(), nil, nil)
-	return ctx.WithValue(LoggerKey,
-		&log.Logger{
-			Formatter: log.StandardLogger().Formatter,
-			Out:       log.StandardLogger().Out,
-			Hooks:     log.StandardLogger().Hooks,
-			Level:     log.StandardLogger().Level,
-		},
-	)
+	return New(nil)
 }
 
 // WithRequestRoute returns a new context with the injected *http.Request

--- a/api/tests/tests.go
+++ b/api/tests/tests.go
@@ -213,7 +213,7 @@ func (th *testHarness) run(
 			wg.Add(1)
 			go func(x int, config gofig.Config) {
 				defer wg.Done()
-				server, errs, err := apiserver.Serve(config)
+				server, errs, err := apiserver.Serve(nil, config)
 				if err != nil {
 					th.closeServers(t)
 					t.Fatal(err)
@@ -228,7 +228,7 @@ func (th *testHarness) run(
 
 				th.servers = append(th.servers, server)
 
-				c, err := client.New(config)
+				c, err := client.New(nil, config)
 				assert.NoError(t, err)
 				assert.NotNil(t, c)
 				if err != nil || c == nil {
@@ -259,7 +259,7 @@ func (th *testHarness) run(
 				go func(test APITestFunc, x int, config gofig.Config) {
 
 					defer wg.Done()
-					server, errs, err := apiserver.Serve(config)
+					server, errs, err := apiserver.Serve(nil, config)
 					if err != nil {
 						th.closeServers(t)
 						t.Fatal(err)
@@ -274,7 +274,7 @@ func (th *testHarness) run(
 
 					th.servers = append(th.servers, server)
 
-					c, err := client.New(config)
+					c, err := client.New(nil, config)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/c/libstor-c/libstor-c_utils.go
+++ b/c/libstor-c/libstor-c_utils.go
@@ -91,7 +91,7 @@ func newWithConfig(configPath string) (types.Client, error) {
 	if err := config.ReadConfigFile(configPath); err != nil {
 		return nil, err
 	}
-	return client.New(config)
+	return client.New(nil, config)
 }
 
 func getClient(clientID C.h) (types.Client, error) {

--- a/c/libstor-s/libstor-s_exported.go
+++ b/c/libstor-s/libstor-s_exported.go
@@ -68,7 +68,7 @@ func serve(
 		os.Setenv("LIBSTORAGE_HOST", szHost)
 	}
 
-	_, errs, err := server.Serve(config)
+	_, errs, err := server.Serve(nil, config)
 	if err != nil {
 		return C.CString(err.Error())
 	}

--- a/cli/lss/lss.go
+++ b/cli/lss/lss.go
@@ -89,7 +89,7 @@ func Run() {
 			os.Exit(0)
 		}
 
-		s, errs, err := server.Serve(config)
+		s, errs, err := server.Serve(nil, config)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: error: %v\n", os.Args[0], err)
 			os.Exit(1)
@@ -165,7 +165,7 @@ func Run() {
 
 	server.CloseOnAbort()
 
-	_, errs, err := server.Serve(config)
+	_, errs, err := server.Serve(nil, config)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: error: %v\n", os.Args[0], err)
 		os.Exit(1)

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/akutz/gofig"
 
+	gocontext "golang.org/x/net/context"
+
 	"github.com/emccode/libstorage/api/context"
 	"github.com/emccode/libstorage/api/registry"
 	"github.com/emccode/libstorage/api/types"
@@ -25,7 +27,7 @@ type client struct {
 }
 
 // New returns a new libStorage client.
-func New(config gofig.Config) (types.Client, error) {
+func New(goCtx gocontext.Context, config gofig.Config) (types.Client, error) {
 
 	if config == nil {
 		var err error
@@ -42,7 +44,7 @@ func New(config gofig.Config) (types.Client, error) {
 		err error
 	)
 
-	c = &client{ctx: context.Background(), config: config}
+	c = &client{ctx: context.New(goCtx), config: config}
 	c.ctx = c.ctx.WithValue(context.ClientKey, c)
 
 	logFields := log.Fields{}

--- a/drivers/storage/libstorage/libstorage_driver.go
+++ b/drivers/storage/libstorage/libstorage_driver.go
@@ -41,7 +41,7 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 
 	addr := config.GetString(types.ConfigHost)
 	d.ctx = ctx.WithValue(context.HostKey, addr)
-	ctx.Debug("got configured host address")
+	d.ctx.Debug("got configured host address")
 
 	proto, lAddr, err := gotil.ParseAddress(addr)
 	if err != nil {

--- a/libstorage.go
+++ b/libstorage.go
@@ -35,6 +35,7 @@ package libstorage
 
 import (
 	"github.com/akutz/gofig"
+	"golang.org/x/net/context"
 
 	"github.com/emccode/libstorage/api/server"
 	"github.com/emccode/libstorage/api/types"
@@ -48,9 +49,10 @@ import (
 // a config instance with the correct properties to specify service
 // information for a libStorage server.
 func New(
+	ctx context.Context,
 	config gofig.Config) (types.Client, types.Server, <-chan error, error) {
 
-	s, errs, err := server.Serve(config)
+	s, errs, err := server.Serve(ctx, config)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -59,7 +61,7 @@ func New(
 		config.Set(types.ConfigHost, s.Addrs()[0])
 	}
 
-	c, err := client.New(config)
+	c, err := client.New(ctx, config)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
This patch requires the creation of the Client & Server components to
receive a context parameter. This argument can be nil, but if specified,
it enables a through-line of additional runtime data from the embedding
application into the libStorage components.