### PR TITLE
Fix for Local Devices sans VolID

### DIFF
--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -680,7 +680,9 @@ func TestLocalDevices(t *testing.T) {
 		if len(p) > 1 {
 			v = p[1]
 		}
-		dfcMap[k] = v
+		if len(v) > 0 {
+			dfcMap[k] = v
+		}
 	}
 
 	apitests.RunGroup(


### PR DESCRIPTION
This patch fixes issue 173 where drivers with local devices with no
volume IDs caused the remote call to fail.