### PR TITLE
Fix for Volume.MountPoint()

### DIFF
--- a/api/registry/registry_integration.go
+++ b/api/registry/registry_integration.go
@@ -130,6 +130,13 @@ func (d *idm) Mount(
 	if err != nil {
 		return "", nil, err
 	}
+
+	// if the volume has attachments assign the new mount point to the
+	// MountPoint field of the first attachment element
+	if len(vol.Attachments) > 0 {
+		vol.Attachments[0].MountPoint = mp
+	}
+
 	d.incCount(volumeName)
 	return mp, vol, err
 }


### PR DESCRIPTION
This patch resolves issue #174 where the Volume.MountPoint() function
returns an empty string after the IntegrationDriver.Mount() function.
The real reason is because a second Volume inspection operation should
be executed to populate the mapping data, but to avoid the round-trip,
the mount point is now directly set on th volume's attachment object.