### PR TITLE
Dependency Updates / Logging Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.a
 *.d
 *.out
-*.lock
 libstorage.paw
 .site/
 site/

--- a/api/registry/registry_integration.go
+++ b/api/registry/registry_integration.go
@@ -44,23 +44,13 @@ func (d *idm) Init(ctx types.Context, config gofig.Config) error {
 		_, _ = d.List(context.Background(), store)
 	}
 
-	// TODO - replace the description data removed from this location.
-	//
-	//        8879d4ce41bdb6617413df9e18172b131ce155cc was the last commit
-	//        that contained the info.
-	//
-	//        this info was removed due to its being mishandled with regards
-	//        to its approach being orthagonal to what was recommended by the
-	//        project lead in addition to the verbosity of the information.
-	//
-	//        additionally, the choice to log the information so far removed
-	//        from its application is misguided as configuration data is
-	//        dynamic and may be invalid or incorrect from what would be shown
-	//        at this location compared to when it is used
-	//
-	//        the excised data will be reintroduced later in a more considered
-	//        manner that's consistent with the project's overall architecture
-	//        and design
+	ctx.WithFields(log.Fields{
+		types.ConfigIgVolOpsPathCache:         d.pathCache(),
+		types.ConfigIgVolOpsUnmountIgnoreUsed: d.ignoreUsedCount(),
+		types.ConfigIgVolOpsMountPreempt:      d.preempt(),
+		types.ConfigIgVolOpsCreateDisable:     d.disableCreate(),
+		types.ConfigIgVolOpsRemoveDisable:     d.disableRemove(),
+	}).Info("libStorage integration driver successfully initialized")
 
 	return nil
 }

--- a/api/types/types_config.go
+++ b/api/types/types_config.go
@@ -3,6 +3,11 @@ package types
 // ConfigKey is a configuration key.
 type ConfigKey string
 
+// String returns the string-representation of the ConfigKey.
+func (k ConfigKey) String() string {
+	return string(k)
+}
+
 const (
 	// ConfigRoot is a config key.
 	ConfigRoot = "libstorage"

--- a/drivers/integration/docker/docker.go
+++ b/drivers/integration/docker/docker.go
@@ -56,23 +56,16 @@ func newDriver() types.IntegrationDriver {
 func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 	d.config = config
 
-	// TODO - replace the description data removed from this location.
-	//
-	//        8879d4ce41bdb6617413df9e18172b131ce155cc was the last commit
-	//        that contained the info.
-	//
-	//        this info was removed due to its being mishandled with regards
-	//        to its approach being orthagonal to what was recommended by the
-	//        project lead in addition to the verbosity of the information.
-	//
-	//        additionally, the choice to log the information so far removed
-	//        from its application is misguided as configuration data is
-	//        dynamic and may be invalid or incorrect from what would be shown
-	//        at this location compared to when it is used
-	//
-	//        the excised data will be reintroduced later in a more considered
-	//        manner that's consistent with the project's overall architecture
-	//        and design
+	ctx.WithFields(log.Fields{
+		types.ConfigIgVolOpsMountRootPath:       d.volumeRootPath(),
+		types.ConfigIgVolOpsCreateDefaultType:   d.volumeType(),
+		types.ConfigIgVolOpsCreateDefaultIOPS:   d.iops(),
+		types.ConfigIgVolOpsCreateDefaultSize:   d.size(),
+		types.ConfigIgVolOpsCreateDefaultAZ:     d.availabilityZone(),
+		types.ConfigIgVolOpsCreateDefaultFsType: d.fsType(),
+		types.ConfigIgVolOpsMountPath:           d.mountDirPath(),
+		types.ConfigIgVolOpsCreateImplicit:      d.volumeCreateImplicit(),
+	}).Info("docker integration driver successfully initialized")
 
 	return nil
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 0b1c2794d82975d611e966e8102fd95d1bee1ff1b81e2d592f26026e41c2d65e
-updated: 2016-06-08T17:21:16.808220531-05:00
+hash: a373a5ff1909ca796eb4f3b1f484b214c212d184143014c377823003b846b5fb
+updated: 2016-06-10T13:02:27.492360638-05:00
 imports:
 - name: github.com/akutz/gofig
-  version: 6485951b06f312fe01ad7ba39978513b902dbd50
+  version: 697c16916338166671910eeaccc50f21e3c10726
 - name: github.com/akutz/golf
   version: e26bdd995cb746e431d42ea303ebe7622389d29f
 - name: github.com/akutz/goof
@@ -71,22 +71,20 @@ imports:
 - name: github.com/spf13/pflag
   version: b084184666e02084b8ccb9b704bf0d79c466eb1d
   repo: https://github.com/spf13/pflag
-  vcs: git
 - name: github.com/spf13/viper
   version: 317ec73d0d7507658ee3be15866b445d6d921848
   repo: https://github.com/akutz/viper.git
-  vcs: git
 - name: github.com/stretchr/testify
   version: 8d64eb7173c7753d6419fd4a9caf057398611364
   subpackages:
   - assert
 - name: golang.org/x/net
-  version: 313cf39d4ac368181bce6960ac9be9e7cee67e68
+  version: 3f122ce3dbbe488b7e6a8bdb26f41edec852a40b
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/sys
-  version: 076b546753157f758b316e59bcb51e6807c04057
+  version: b44883b474ffefa37335017174e397412b633a4f
   subpackages:
   - unix
 - name: gopkg.in/fsnotify.v1
@@ -94,5 +92,4 @@ imports:
 - name: gopkg.in/yaml.v2
   version: b4a9f8c4b84c6c4256d669c649837f1441e4b050
   repo: https://github.com/akutz/yaml.git
-  vcs: git
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,9 +9,13 @@ import:
     ref:     feature/logrus-aware-types
     repo:    https://github.com/akutz/logrus
   - package: github.com/akutz/gofig
+    version: v0.1.4
   - package: github.com/akutz/gotil
+    version: v0.1.0
   - package: github.com/akutz/goof
+    version: v0.1.0
   - package: github.com/akutz/golf
+    version: v0.1.1
   - package: github.com/cesanta/validate-json
 
 ################################################################################

--- a/imports/config/imports_config.go
+++ b/imports/config/imports_config.go
@@ -34,12 +34,12 @@ func init() {
 		defaultVal interface{},
 		description string,
 		keyVal types.ConfigKey,
-		args ...string) {
+		args ...interface{}) {
 
 		if args == nil {
-			args = []string{string(keyVal)}
+			args = []interface{}{keyVal}
 		} else {
-			args = append([]string{string(keyVal)}, args...)
+			args = append([]interface{}{keyVal}, args...)
 		}
 
 		r.Key(keyType, "", defaultVal, description, args...)


### PR DESCRIPTION
This patch updates the project dependencies in `glide.yaml` and `glide.lock` as well as brings the code in line with Gofig updates. Finally, in lieu of a full Config Key refactor which is ongoing, the information removed in commit 5dada4fe7c1697ad240a945f3a26ce1640ed9a86 has been reintroduced in a temporary capacity until it is handed over to the new configuration key system.

This PR is a subset of the work occurring over on [this branch](https://github.com/akutz/libstorage/tree/feature/config-info), but that work is not ready yet, and without additional assitance it won't be in time for this release. I've approached several others in hopes they'd provide said assistance, but except for @jonasrosland, no one has been able to contribute any ideas. 