### PR TITLE
Marshal to YAML Enhancements

### DIFF
--- a/api/types/types_instanceid.go
+++ b/api/types/types_instanceid.go
@@ -17,7 +17,7 @@ type InstanceIDMap map[string]*InstanceID
 type InstanceID struct {
 
 	// ID is the simple part of the InstanceID.
-	ID string `json:"id"`
+	ID string `json:"id" yaml:"id"`
 
 	// Driver is the name of the StorageExecutor that created the InstanceID
 	// as well as the name of the StorageDriver for which the InstanceID is
@@ -144,13 +144,11 @@ func (i *InstanceID) UnmarshalText(value []byte) error {
 
 // MarshalJSON marshals the InstanceID to JSON.
 func (i *InstanceID) MarshalJSON() ([]byte, error) {
-
 	return json.Marshal(&struct {
 		ID       string          `json:"id"`
 		Driver   string          `json:"driver"`
 		Metadata json.RawMessage `json:"metadata,omitempty"`
 	}{i.ID, i.Driver, i.metadata})
-
 }
 
 // UnmarshalJSON marshals the InstanceID to JSON.
@@ -171,4 +169,22 @@ func (i *InstanceID) UnmarshalJSON(data []byte) error {
 	i.metadata = iid.Metadata
 
 	return nil
+}
+
+// MarshalYAML returns the object to marshal to the YAML representation of the
+// InstanceID.
+func (i *InstanceID) MarshalYAML() (interface{}, error) {
+
+	var metadata map[string]interface{}
+	if len(i.metadata) > 0 {
+		if err := json.Unmarshal(i.metadata, &metadata); err != nil {
+			return nil, err
+		}
+	}
+
+	return &struct {
+		ID       string                 `yaml:"id"`
+		Driver   string                 `yaml:"driver"`
+		Metadata map[string]interface{} `yaml:"metadata,omitempty"`
+	}{i.ID, i.Driver, metadata}, nil
 }

--- a/api/types/types_instanceid_test.go
+++ b/api/types/types_instanceid_test.go
@@ -2,7 +2,10 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
+
+	"gopkg.in/yaml.v1"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -133,4 +136,23 @@ func TestInstanceIDUnmarshalText(t *testing.T) {
 	iid := &InstanceID{}
 	err := iid.UnmarshalText([]byte("scaleio="))
 	assert.NoError(t, err)
+}
+
+func TestInstanceIDMarshalToYAML(t *testing.T) {
+
+	iid := &InstanceID{
+		ID:     "hi",
+		Driver: "vfs",
+	}
+	iid.MarshalMetadata(map[string]interface{}{
+		"key1": "val1",
+		"key2": 2,
+	})
+
+	out, err := yaml.Marshal(iid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(string(out))
 }

--- a/api/types/types_localdevices.go
+++ b/api/types/types_localdevices.go
@@ -22,7 +22,7 @@ type LocalDevices struct {
 	Driver string `json:"driver"`
 
 	// DeviceMap is voluem to device mappings.
-	DeviceMap map[string]string `json:"deviceMap"`
+	DeviceMap map[string]string `json:"deviceMap,omitempty" yaml:"deviceMap,omitempty"`
 }
 
 // String returns the string representation of a LocalDevices object.
@@ -93,7 +93,6 @@ func (l *LocalDevices) UnmarshalText(value []byte) error {
 
 // MarshalJSON marshals the InstanceID to JSON.
 func (l *LocalDevices) MarshalJSON() ([]byte, error) {
-
 	return json.Marshal(&struct {
 		Driver    string            `json:"driver"`
 		DeviceMap map[string]string `json:"deviceMap"`
@@ -116,6 +115,15 @@ func (l *LocalDevices) UnmarshalJSON(data []byte) error {
 	l.DeviceMap = ldm.DeviceMap
 
 	return nil
+}
+
+// MarshalYAML returns the object to marshal to the YAML representation of the
+// LocalDevices.
+func (l *LocalDevices) MarshalYAML() (interface{}, error) {
+	return &struct {
+		Driver    string            `json:"driver" yaml:"driver"`
+		DeviceMap map[string]string `json:"deviceMap,omitempty" yaml:"deviceMap,omitempty"`
+	}{l.Driver, l.DeviceMap}, nil
 }
 
 // byString  implements sort.Interface for []string.

--- a/api/types/types_localdevices_test.go
+++ b/api/types/types_localdevices_test.go
@@ -1,7 +1,10 @@
 package types
 
 import (
+	"fmt"
 	"testing"
+
+	"gopkg.in/yaml.v1"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -49,4 +52,12 @@ func TestLocalDevicesMarshalJSON(t *testing.T) {
 	assert.NoError(t, ld2.UnmarshalJSON(buf))
 
 	assert.EqualValues(t, ld1, ld2)
+}
+
+func TestLocalDevicesMarshalToYAML(t *testing.T) {
+	out, err := yaml.Marshal(newLocalDevicesObj())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(string(out))
 }

--- a/api/types/types_model.go
+++ b/api/types/types_model.go
@@ -36,26 +36,26 @@ type ExecutorsMap map[string]*ExecutorInfo
 // Instance provides information about a storage object.
 type Instance struct {
 	// The ID of the instance to which the object is connected.
-	InstanceID *InstanceID `json:"instanceID"`
+	InstanceID *InstanceID `json:"instanceID" yaml:"instanceID,omitempty"`
 
 	// The name of the instance.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty" yaml:",omitempty"`
 
 	// The name of the provider that owns the object.
-	ProviderName string `json:"providerName"`
+	ProviderName string `json:"providerName" yaml:"providerName,omitempty"`
 
 	// The region from which the object originates.
-	Region string `json:"region"`
+	Region string `json:"region,omitempty" yaml:",omitempty"`
 
 	// Fields are additional properties that can be defined for this type.
-	Fields map[string]string `json:"fields,omitempty"`
+	Fields map[string]string `json:"fields,omitempty" yaml:",omitempty"`
 }
 
 // MountInfo reveals information about a particular mounted filesystem. This
 // struct is populated from the content in the /proc/<pid>/mountinfo file.
 type MountInfo struct {
 	// ID is a unique identifier of the mount (may be reused after umount).
-	ID int `json:"id"`
+	ID int `json:"id" yaml:"id"`
 
 	// Parent indicates the ID of the mount parent (or of self for the top of
 	// the mount tree).
@@ -73,7 +73,7 @@ type MountInfo struct {
 	Root string `json:"root"`
 
 	// MountPoint indicates the mount point relative to the process's root.
-	MountPoint string `json:"mountPoint"`
+	MountPoint string `json:"mountPoint" yaml:"mountPoint"`
 
 	// Opts represents mount-specific options.
 	Opts string `json:"opts"`
@@ -82,79 +82,79 @@ type MountInfo struct {
 	Optional string `json:"optional"`
 
 	// FSType indicates the type of filesystem, such as EXT3.
-	FSType string `json:"fsType"`
+	FSType string `json:"fsType" yaml:"fsType"`
 
 	// Source indicates filesystem specific information or "none".
 	Source string `json:"source"`
 
 	// VFSOpts represents per super block options.
-	VFSOpts string `json:"vfsOpts"`
+	VFSOpts string `json:"vfsOpts" yaml:"vfsOpts"`
 
 	// Fields are additional properties that can be defined for this type.
-	Fields map[string]string `json:"fields,omitempty"`
+	Fields map[string]string `json:"fields,omitempty" yaml:",omitempty"`
 }
 
 // Snapshot provides information about a storage-layer snapshot.
 type Snapshot struct {
 	// A description of the snapshot.
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:",omitempty"`
 
 	// The name of the snapshot.
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty" yaml:",omitempty"`
 
 	// The snapshot's ID.
-	ID string `json:"id"`
+	ID string `json:"id" yaml:"id"`
 
 	// The time (epoch) at which the request to create the snapshot was submitted.
-	StartTime int64 `json:"startTime,omitempty"`
+	StartTime int64 `json:"startTime,omitempty" yaml:"startTime,omitempty"`
 
 	// The status of the snapshot.
-	Status string `json:"status,omitempty"`
+	Status string `json:"status,omitempty" yaml:",omitempty"`
 
 	// The ID of the volume to which the snapshot belongs.
-	VolumeID string `json:"volumeID,omitempty"`
+	VolumeID string `json:"volumeID,omitempty" yaml:"volumeID,omitempty"`
 
 	// The size of the volume to which the snapshot belongs.
-	VolumeSize int64 `json:"volumeSize,omitempty"`
+	VolumeSize int64 `json:"volumeSize,omitempty" yaml:"volumeSize,omitempty"`
 
 	// Fields are additional properties that can be defined for this type.
-	Fields map[string]string `json:"fields,omitempty"`
+	Fields map[string]string `json:"fields,omitempty" yaml:",omitempty"`
 }
 
 // Volume provides information about a storage volume.
 type Volume struct {
 	// The volume's attachments.
-	Attachments []*VolumeAttachment `json:"attachments,omitempty"`
+	Attachments []*VolumeAttachment `json:"attachments,omitempty" yaml:",omitempty"`
 
 	// The availability zone for which the volume is available.
-	AvailabilityZone string `json:"availabilityZone,omitempty"`
+	AvailabilityZone string `json:"availabilityZone,omitempty" yaml:"availabilityZone,omitempty"`
 
 	// The volume IOPs.
-	IOPS int64 `json:"iops,omitempty"`
+	IOPS int64 `json:"iops,omitempty" yaml:"iops,omitempty"`
 
 	// The name of the volume.
 	Name string `json:"name"`
 
 	// NetworkName is the name the device is known by in order to discover
 	// locally.
-	NetworkName string `json:"networkName,omitempty"`
+	NetworkName string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
 
 	// The size of the volume.
-	Size int64 `json:"size,omitempty"`
+	Size int64 `json:"size,omitempty" yaml:",omitempty"`
 
 	// The volume status.
-	Status string `json:"status,omitempty"`
+	Status string `json:"status,omitempty" yaml:",omitempty"`
 
 	// ID is a piece of information that uniquely identifies the volume on
 	// the storage platform to which the volume belongs. A volume ID is not
 	// guaranteed to be unique across multiple, configured services.
-	ID string `json:"id"`
+	ID string `json:"id" yaml:"id"`
 
 	// The volume type.
 	Type string `json:"type"`
 
 	// Fields are additional properties that can be defined for this type.
-	Fields map[string]string `json:"fields,omitempty"`
+	Fields map[string]string `json:"fields,omitempty" yaml:",omitempty"`
 }
 
 // VolumeName returns the volume's name.
@@ -175,24 +175,24 @@ func (v *Volume) MountPoint() string {
 type VolumeAttachment struct {
 	// The name of the device on which the volume to which the object is
 	// attached is mounted.
-	DeviceName string `json:"deviceName"`
+	DeviceName string `json:"deviceName" yaml:"deviceName,omitempty"`
 
 	// MountPoint is the mount point for the volume. This field is set when a
 	// volume is retrieved via an integration driver.
-	MountPoint string `json:"mountPoint,omitempty"`
+	MountPoint string `json:"mountPoint,omitempty" yaml:"mountPoint,omitempty"`
 
 	// The ID of the instance on which the volume to which the attachment
 	// belongs is mounted.
-	InstanceID *InstanceID `json:"instanceID"`
+	InstanceID *InstanceID `json:"instanceID" yaml:"instanceID,omitempty"`
 
 	// The status of the attachment.
-	Status string `json:"status"`
+	Status string `json:"status" yaml:",omitempty"`
 
 	// The ID of the volume to which the attachment belongs.
-	VolumeID string `json:"volumeID"`
+	VolumeID string `json:"volumeID" yaml:"volumeID,omitempty"`
 
 	// Fields are additional properties that can be defined for this type.
-	Fields map[string]string `json:"fields,omitempty"`
+	Fields map[string]string `json:"fields,omitempty" yaml:",omitempty"`
 }
 
 // VolumeDevice provides information about a volume's backing storage
@@ -202,25 +202,25 @@ type VolumeDevice struct {
 	Name string `json:"name"`
 
 	// The ID of the instance to which the device is connected.
-	InstanceID *InstanceID `json:"instanceID"`
+	InstanceID *InstanceID `json:"instanceID,omitempty" yaml:"instanceID,omitempty"`
 
 	// The name of the network on which the device resides.
-	NetworkName string `json:"networkName"`
+	NetworkName string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
 
 	// The name of the provider that owns the block device.
-	ProviderName string `json:"providerName"`
+	ProviderName string `json:"providerName,omitempty" yaml:"providerName,omitempty"`
 
 	// The region from which the device originates.
-	Region string `json:"region"`
+	Region string `json:"region,omitempty" yaml:",omitempty"`
 
 	// The device status.
 	Status string `json:"status"`
 
 	// The ID of the volume for which the device is mounted.
-	VolumeID string `json:"volumeID"`
+	VolumeID string `json:"volumeID" yaml:"volumeID"`
 
 	// Fields are additional properties that can be defined for this type.
-	Fields map[string]string `json:"fields,omitempty"`
+	Fields map[string]string `json:"fields,omitempty" yaml:",omitempty"`
 }
 
 // ExecutorInfo contains information about a client-side executor, such as
@@ -232,13 +232,13 @@ type ExecutorInfo struct {
 
 	// MD5Checksum is the MD5 checksum of the executor. This can be used to
 	// determine if a local copy of the executor needs to be updated.
-	MD5Checksum string `json:"md5checksum"`
+	MD5Checksum string `json:"md5checksum" yaml:"md5checksum"`
 
 	// Size is the size of the executor in bytes.
 	Size int64 `json:"size"`
 
 	// LastModified is the time the executor was last modified as an epoch.
-	LastModified int64 `json:"lastModified"`
+	LastModified int64 `json:"lastModified" yaml:"lastModified"`
 }
 
 // ServiceInfo is information about a service.
@@ -247,7 +247,7 @@ type ServiceInfo struct {
 	Name string `json:"name"`
 
 	// Instance is the service's instance.
-	Instance *Instance `json:"instance,omitempty"`
+	Instance *Instance `json:"instance,omitempty" yaml:",omitempty"`
 
 	// Driver is the name of the driver registered for the service.
 	Driver *DriverInfo `json:"driver"`
@@ -262,7 +262,7 @@ type DriverInfo struct {
 	Type StorageType `json:"type"`
 
 	// NextDevice is the next available device information for the service.
-	NextDevice *NextDeviceInfo `json:"nextDevice,omitempty"`
+	NextDevice *NextDeviceInfo `json:"nextDevice,omitempty" yaml:"nextDevice,omitempty"`
 }
 
 // NextDeviceInfo assists the libStorage client in determining the
@@ -312,27 +312,27 @@ const (
 // Task is a representation of an asynchronous, long-running task.
 type Task struct {
 	// ID is the task's ID.
-	ID int `json:"id"`
+	ID int `json:"id" yaml:"id"`
 
 	// User is the name of the user that created the task.
-	User string `json:"user,omitempty"`
+	User string `json:"user,omitempty" yaml:",omitempty"`
 
 	// CompleteTime is the time stamp when the task was completed
 	// (whether success or failure).
-	CompleteTime int64 `json:"completeTime,omitempty"`
+	CompleteTime int64 `json:"completeTime,omitempty" yaml:"completeTime,omitempty"`
 
 	// QueueTime is the time stamp when the task was created.
-	QueueTime int64 `json:"queueTime"`
+	QueueTime int64 `json:"queueTime" yaml:"queueTime"`
 
 	// StartTime is the time stamp when the task started running.
-	StartTime int64 `json:"startTime,omitempty"`
+	StartTime int64 `json:"startTime,omitempty" yaml:"startTime,omitempty"`
 
 	// State is the current state of the task.
 	State TaskState `json:"state"`
 
 	// Result holds the result of the task.
-	Result interface{} `json:"result,omitempty"`
+	Result interface{} `json:"result,omitempty" yaml:",omitempty"`
 
 	// Error contains the error if the task was unsuccessful.
-	Error error `json:"error,omitempty"`
+	Error error `json:"error,omitempty" yaml:",omitempty"`
 }

--- a/api/types/types_model_test.go
+++ b/api/types/types_model_test.go
@@ -1,0 +1,87 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	"gopkg.in/yaml.v1"
+)
+
+func TestVolumeMarshalToYAML(t *testing.T) {
+
+	v := &Volume{
+		ID:   "vol-000",
+		Name: "Volume 000",
+		Attachments: []*VolumeAttachment{
+			&VolumeAttachment{
+				InstanceID: &InstanceID{
+					ID:     "hi",
+					Driver: "vfs",
+				},
+				VolumeID: "vol-000",
+			},
+		},
+	}
+
+	out, err := yaml.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(string(out))
+
+	i := &Instance{
+		InstanceID: &InstanceID{
+			ID:     "hi",
+			Driver: "vfs",
+		},
+	}
+
+	out, err = yaml.Marshal(i)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(string(out))
+}
+
+func TestInstanceMarshalToYAML(t *testing.T) {
+
+	iid := &InstanceID{
+		ID:     "hi",
+		Driver: "vfs",
+	}
+	iid.MarshalMetadata(map[string]interface{}{
+		"key1": "val1",
+		"key2": 2,
+	})
+
+	i := &Instance{
+		Name:       "MyVFSInstance",
+		InstanceID: iid,
+	}
+
+	out, err := yaml.Marshal(i)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(string(out))
+}
+
+func TestInstanceWithOnlyInstanceIDMarshalToYAML(t *testing.T) {
+
+	i := &Instance{
+		InstanceID: &InstanceID{
+			ID:     "hi",
+			Driver: "vfs",
+		},
+	}
+
+	out, err := yaml.Marshal(i)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(string(out))
+}

--- a/api/types/types_tx.go
+++ b/api/types/types_tx.go
@@ -16,7 +16,7 @@ type TxTimestamp time.Time
 type Transaction struct {
 
 	// ID is the transaction's ID.
-	ID *UUID `json:"id"`
+	ID *UUID `json:"id" yaml:"id"`
 
 	// Created is the UTC timestampe at which the transaction was created.
 	Created TxTimestamp `json:"created"`

--- a/api/types/types_version.go
+++ b/api/types/types_version.go
@@ -57,3 +57,22 @@ func (v *VersionInfo) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(ver)
 }
+
+// MarshalYAML returns the object to marshal to the YAML representation of the
+// version.
+func (v *VersionInfo) MarshalYAML() (interface{}, error) {
+
+	return &struct {
+		SemVer         string `yaml:"semver"`
+		ShaLong        string `yaml:"shaLong"`
+		BuildTimestamp int64  `yaml:"buildTimestamp"`
+		Branch         string `yaml:"branch"`
+		Arch           string `yaml:"arch"`
+	}{
+		SemVer:         v.SemVer,
+		ShaLong:        v.ShaLong,
+		BuildTimestamp: v.BuildTimestamp.Unix(),
+		Branch:         v.Branch,
+		Arch:           v.Arch,
+	}, nil
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a373a5ff1909ca796eb4f3b1f484b214c212d184143014c377823003b846b5fb
-updated: 2016-06-10T13:02:27.492360638-05:00
+hash: 1be91a8105c46e6885db9d305fa22f7d5460a21f5c9815e308ed9cd61695c7d3
+updated: 2016-06-14T13:00:38.335910394-05:00
 imports:
 - name: github.com/akutz/gofig
   version: 697c16916338166671910eeaccc50f21e3c10726
@@ -38,6 +38,9 @@ imports:
   repo: https://github.com/emccode/goscaleio
   subpackages:
   - types/v1
+- name: github.com/go-yaml/yaml
+  version: b4a9f8c4b84c6c4256d669c649837f1441e4b050
+  repo: https://github.com/akutz/yaml.git
 - name: github.com/gorilla/context
   version: aed02d124ae4a0e94fea4541c8effd05bf0c8296
 - name: github.com/gorilla/mux
@@ -84,11 +87,14 @@ imports:
   - context
   - context/ctxhttp
 - name: golang.org/x/sys
-  version: b44883b474ffefa37335017174e397412b633a4f
+  version: 5a8c7f28c1853e998847117cf1f3fe96ce88a59f
   subpackages:
   - unix
 - name: gopkg.in/fsnotify.v1
   version: 30411dbcefb7a1da7e84f75530ad3abe4011b4f8
+- name: gopkg.in/yaml.v1
+  version: b4a9f8c4b84c6c4256d669c649837f1441e4b050
+  repo: https://github.com/akutz/yaml.git
 - name: gopkg.in/yaml.v2
   version: b4a9f8c4b84c6c4256d669c649837f1441e4b050
   repo: https://github.com/akutz/yaml.git

--- a/glide.yaml
+++ b/glide.yaml
@@ -50,3 +50,12 @@ import:
 ################################################################################
 
   - package: github.com/stretchr/testify
+  - package: github.com/go-yaml/yaml
+    ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
+    repo:    https://github.com/akutz/yaml.git
+  - package: gopkg.in/yaml.v1
+    ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
+    repo:    https://github.com/akutz/yaml.git
+  - package: gopkg.in/yaml.v2
+    ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
+    repo:    https://github.com/akutz/yaml.git


### PR DESCRIPTION
This patch provides the API's modeled types with the ability to influence how they are marshaled to YAML via the go-yaml package.