### PR TITLE
Checking for attached volumes with Isilon Driver causes a Panic

### DIFF
--- a/drivers/storage/isilon/storage/isilon_storage.go
+++ b/drivers/storage/isilon/storage/isilon_storage.go
@@ -174,27 +174,15 @@ func (d *driver) getVolumeAttachments(ctx types.Context) (
 		return nil, err
 	}
 
-	// should be using this, but instanceID is coming back either blank or
-	// with metadata today
-	// iid := ctx.InstanceID()
-
-	ii, err := d.InstanceInspect(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	iid := ii.InstanceID
-
-	ld, err := d.LocalDevices(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
+	iid, iidOK := context.InstanceID(ctx)
+	ld, ldOK := context.LocalDevices(ctx)
 
 	var atts []*types.VolumeAttachment
 	for _, export := range exports {
 		var dev string
 		var status string
 		for _, c := range export.Clients {
-			if c == iid.ID {
+			if iidOK && ldOK && c == iid.ID {
 				dev = d.nfsMountPath(export.ExportPath)
 				if _, ok := ld.DeviceMap[dev]; ok {
 					status = "Exported and Mounted"


### PR DESCRIPTION
When CURLing the following endpoint on a libstorage client that has no instanceID a panic is seen on the server. Below is the logs.

`curl http://0.0.0.0:7981/volumes/isilonservice`

Stack Trace
```
panic: interface conversion: interface {} is nil, not *types.InstanceID

goroutine 33 [running]:
panic(0xce83a0, 0xc8202de740)
    /usr/local/go/src/runtime/panic.go:464 +0x3e6
github.com/emccode/libstorage/api/context.MustInstanceID(0x7f829905d1f8, 0xc82049dcb0, 0xc82049dcb0)
    /home/ubuntu/gocode/src/github.com/emccode/libstorage/api/context/context.go:234 +0xb3
github.com/emccode/libstorage/drivers/storage/isilon/storage.(*driver).InstanceInspect(0xc82014d780, 0x7f829905d0d0, 0xc82049dcb0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /home/ubuntu/gocode/src/github.com/emccode/libstorage/drivers/storage/isilon/storage/isilon_storage.go:126 +0x75
github.com/emccode/libstorage/drivers/storage/isilon/storage.(*driver).getVolumeAttachments(0xc82014d780, 0x7f829905d0d0, 0xc82049dcb0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /home/ubuntu/gocode/src/github.com/emccode/libstorage/drivers/storage/isilon/storage/isilon_storage.go:181 +0x113
github.com/emccode/libstorage/drivers/storage/isilon/storage.(*driver).getVolume(0xc82014d780, 0x7f829905d0d0, 0xc82049dcb0, 0x0, 0x0, 0x0, 0x0, 0xc820315e01, 0x0, 0x0, ...)
    /home/ubuntu/gocode/src/github.com/emccode/libstorage/drivers/storage/isilon/storage/isilon_storage.go:521 +0x1d3
github.com/emccode/libstorage/drivers/storage/isilon/storage.(*driver).Volumes(0xc82014d780, 0x7f829905d0d0, 0xc82049dcb0, 0xc8204011e0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /home/ubuntu/gocode/src/github.com/emccode/libstorage/drivers/storage/isilon/storage/isilon_storage.go:229 +0x85
github.com/emccode/libstorage/api/registry.(*sdm).Volumes(0xc82014d7a0, 0x7f829905d0d0, 0xc82049dcb0, 0xc8204011e0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /home/ubuntu/gocode/src/github.com/emccode/libstorage/api/registry/registry_storage.go:55 +0x103
github.com/emccode/libstorage/api/server/router/volume.getFilteredVolumes(0x7f829905d0d0, 0xc82049dcb0, 0xc820304000, 0x7f8299064308, 0xc82030c100, 0x7f8299063b50, 0xc8201b12c0, 0xc8204011e0, 0x0, 0xc820314e60, ...)
    /home/ubuntu/gocode/src/github.com/emccode/libstorage/api/server/router/volume/volume_routes.go:142 +0x1c9
github.com/emccode/libstorage/api/server/router/volume.(*router).volumesForService.func1(0x7f829905d0d0, 0xc82049dcb0, 0x7f8299063b50, 0xc8201b12c0, 0x0, 0x0, 0x0, 0x0)
    /home/ubuntu/gocode/src/github.com/emccode/libstorage/api/server/router/volume/volume_routes.go:111 +0xaa
github.com/emccode/libstorage/api/server/services.execTask(0xc8203ba420)
    /home/ubuntu/gocode/src/github.com/emccode/libstorage/api/server/services/services_task.go:75 +0x217
github.com/emccode/libstorage/api/server/services.(*storageService).Init.func1(0xc8201b12c0)
    /home/ubuntu/gocode/src/github.com/emccode/libstorage/api/server/services/services_storage.go:29 +0x68
created by github.com/emccode/libstorage/api/server/services.(*storageService).Init
    /home/ubuntu/gocode/src/github.com/emccode/libstorage/api/server/services/services_storage.go:31 +0xea
```

This PR will check if the client has IID before looking for volume attachments