### PR TITLE
Dockerfile for building libstorage with containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+FROM ubuntu:14.04
+MAINTAINER <EMC{code}>
+
+# To build this dockerfile first ensure that it is named "Dockerfile"
+# make sure that a directory "docker_resources" is also present in the same directory as "Dockerfile",
+#   and that "docker_resources" contains the files "go-wrapper" and "get_go-bindata_md5.sh"
+
+# Assuming:
+# Your dockerhub username: dhjohndoe
+# Your github username: ghjohndoe
+# Your REX-Ray fork is checked out in $HOME/go/src/github.com/ghjohndoe/libstorage/
+
+# To build a Docker image using this Dockerfile:
+# docker build -t dhjohndoe/golang-glide:0.1.0 .
+
+# To build libstorage using this Docker image:
+# docker pull dhjohndoe/golang-glide:0.1.0
+# If cutting and pasting the next line remove '\' and '#' characters remember to replace ghjohndoe and dhjohndoe
+# docker run -v $HOME/go/src/github.com/ghjohndoe/libstorage/:/go/src/github.com/emccode/libstorage/ \
+# -v $HOME/build/libstorage/pkg/:/go/pkg/ \
+# -v $HOME/build/libstorage/bin/:/go/bin/ \
+# -w=/go/src/github.com/emccode/libstorage/ dhjohndoe/golang-glide:0.1.0
+
+# after building build resources will be placed in $HOME/build/libstorage/ in the pkg/ and bin/ directories
+
+RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common
+RUN add-apt-repository ppa:masterminds/glide
+
+# gcc for cgo
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        g++ \
+        gcc \
+        git \
+        glide \
+        make \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.6.2
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 e40c36ae71756198478624ed1bb4ce17597b3c19d243f3f0899bb5740d56212a
+
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+    && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+    && tar -C /usr/local -xzf golang.tar.gz \
+    && rm golang.tar.gz
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH
+
+COPY docker_resources/go-wrapper /usr/local/bin/
+
+VOLUME ["/go/src/github.com/emccode/libstorage", "/go/pkg", "/go/bin"]
+
+CMD ["/bin/bash", "-c", "make clean && make version && make deps && make build"]
+
+# manual build steps:
+# make clean
+# make version
+# make deps
+# make build
+# The libstorage build output will be in: /go/bin/ /go/pkg/

--- a/docker_resources/go-wrapper
+++ b/docker_resources/go-wrapper
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -e
+
+usage() {
+	base="$(basename "$0")"
+	cat <<EOUSAGE
+usage: $base command [args]
+This script assumes that is is run from the root of your Go package (for
+example, "/go/src/app" if your GOPATH is set to "/go").
+In Go 1.4, a feature was introduced to supply the canonical "import path" for a
+given package in a comment attached to a package statement
+(https://golang.org/s/go14customimport).
+This script allows us to take a generic directory of Go source files such as
+"/go/src/app" and determine that the canonical "import path" of where that code
+expects to live and reference itself is "github.com/jsmith/my-cool-app".  It
+will then ensure that "/go/src/github.com/jsmith/my-cool-app" is a symlink to
+"/go/src/app", which allows us to build and run it under the proper package
+name.
+For compatibility with versions of Go older than 1.4, the "import path" may also
+be placed in a file named ".godir".
+Available Commands:
+  $base download
+  $base download -u
+    (equivalent to "go get -d [args] [godir]")
+  $base install
+  $base install -race
+    (equivalent to "go install [args] [godir]")
+  $base run
+  $base run -app -specific -arguments
+    (assumes "GOPATH/bin" is in "PATH")
+EOUSAGE
+}
+
+# "shift" so that "$@" becomes the remaining arguments and can be passed along to other "go" subcommands easily
+cmd="$1"
+if ! shift; then
+	usage >&2
+	exit 1
+fi
+
+goDir="$(go list -e -f '{{.ImportComment}}' 2>/dev/null || true)"
+
+if [ -z "$goDir" -a -s .godir ]; then
+	goDir="$(cat .godir)"
+fi
+
+dir="$(pwd -P)"
+if [ "$goDir" ]; then
+	goPath="${GOPATH%%:*}" # this just grabs the first path listed in GOPATH, if there are multiple (which is the detection logic "go get" itself uses, too)
+	goDirPath="$goPath/src/$goDir"
+	mkdir -p "$(dirname "$goDirPath")"
+	if [ ! -e "$goDirPath" ]; then
+		ln -sfv "$dir" "$goDirPath"
+	elif [ ! -L "$goDirPath" ]; then
+		echo >&2 "error: $goDirPath already exists but is unexpectedly not a symlink!"
+		exit 1
+	fi
+	goBin="$goPath/bin/$(basename "$goDir")"
+else
+	goBin="$(basename "$dir")" # likely "app"
+fi
+
+case "$cmd" in
+	download)
+		execCommand=( go get -v -d "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+
+	install)
+		execCommand=( go install -v "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+
+	run)
+		set -x; exec "$goBin" "$@"
+		;;
+
+	*)
+		echo >&2 'error: unknown command:' "$cmd"
+		usage >&2
+		exit 1
+		;;
+esac


### PR DESCRIPTION
Includes an updated Dockerfile to build libstorage using docker. Includes required resources in docker_resources directory.

This Dockerfile does not perform the go-bindata checkout. It is based off of the Ubuntu 14.04 Image.

Run instructions are listed as comments in the Dockerfile.