### PR TITLE
Schema Slowdown Fix

### DIFF
--- a/api/server/services/services.go
+++ b/api/server/services/services.go
@@ -52,7 +52,7 @@ func Init(ctx types.Context, config gofig.Config) error {
 func (sc *serviceContainer) Init(ctx types.Context, config gofig.Config) error {
 	sc.config = config
 
-	if err := sc.taskService.Init(config); err != nil {
+	if err := sc.taskService.Init(ctx, config); err != nil {
 		return err
 	}
 

--- a/api/types/types_config.go
+++ b/api/types/types_config.go
@@ -110,4 +110,8 @@ const (
 
 	// ConfigDeviceScanType is a config key.
 	ConfigDeviceScanType = ConfigRoot + ".device.scanType"
+
+	// ConfigSchemaResponseValidationEnabled is a config key.
+	ConfigSchemaResponseValidationEnabled = ConfigRoot +
+		".schema.responseValidationEnabled"
 )


### PR DESCRIPTION
This patch makes schema response validation an optional step that is disabled by default. The key `libstorage.schema.responseSchemaValidationEnabled` can be set to `true` to enable validation of a response's content against its defined schema.