### PR TITLE
Log Timestamps in Milliseconds

### DIFF
--- a/api/context/context_logger.go
+++ b/api/context/context_logger.go
@@ -16,7 +16,7 @@ const (
 func (ctx *lsc) ctxFields() map[string]interface{} {
 
 	fields := map[string]interface{}{
-		"time": time.Now().UTC().Unix(),
+		"time": time.Now().UTC().UnixNano() / int64(time.Millisecond),
 	}
 
 	for key := Key(keyLoggable - 1); key > keyEOF; key-- {


### PR DESCRIPTION
This patch updates the context logger to emit timestamps as UTC epochs in milliseconds instead of seconds.