### PR TITLE
GOPATH/bin, Gometalinter, Glide Install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,25 @@ before_install:
   - git config --global 'url.https://gopkg.in/fsnotify.v1.insteadof' 'https://gopkg.in/fsnotify.v1/'
   - git config --global 'url.https://github.com/.insteadof' 'git://github.com/'
   - git config --global 'url.https://github.com/.insteadof' 'git@github.com:'
-install:
-  - go get github.com/Masterminds/glide
   - go get github.com/onsi/gomega
   - go get github.com/onsi/ginkgo
   - go get golang.org/x/tools/cmd/cover
+  - make deps
+before_script:
+  - rm -f $GOPATH/bin/libstor-c
+  - rm -f $GOPATH/bin/libstor-s
+  - rm -f $GOPATH/bin/lsx-linux
+  - rm -f $GOPATH/bin/darwin_amd64/lsx-darwin
 script:
-  - make version
-  - make -j deps
+  - make gometalinter-all
   - make -j build
+  - make -j test
+after_success:
   - make -j cover
 cache:
   directories:
   - vendor
+  - $GOPATH/bin
 addons:
   apt:
     sources:


### PR DESCRIPTION
This patch provides three enhancements to the build process:

  1. GOPATH/bin is automatically added and exported to the system's PATH
  variable for the duration of the Makefile's execution. This ensures
  that any commands which invoke a command assumed to be in the PATH via
  $GOPATH/bin will function correctly.

  2. The Gometalinter tool has been integrated into the build process in
  order to ensure consistent, clean, functional code.

  3. The Glide target now uses `glide install` instead of `glide up` in
  order to prevent the creation of a new `glide.lock` file on the build
  agent at the time of a build.