### PR TITLE
Make Gometalinter Optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,7 @@ GO_DEPS += $(GO_BINDATA)
 ################################################################################
 ##                               GOMETALINTER                                 ##
 ################################################################################
+ifneq (1,$(GOMETALINTER_DISABLED))
 GOMETALINTER := $(GOPATH)/bin/gometalinter
 
 $(GOMETALINTER): | $(GOMETALINTER_TOOLS)
@@ -352,7 +353,10 @@ ifeq (1,$(GOMETALINTER_WARN_ENABLED))
 	$(MAKE) gometalinter-warn
 endif
 	$(MAKE) gometalinter-error
-
+else
+gometalinter-all:
+	@echo gometalinter disabled
+endif
 
 ################################################################################
 ##                                  VERSION                                   ##


### PR DESCRIPTION
This patch makes Gometalinter optional. Set the environmental variable
GOMETALINTER_DISABLED=1 to disable the gometalinter tool. The target
`gometalinter-all` is still valid whether the tool is disabled or not.