### PR TITLE
Context Logger Optimizations

### DIFF
--- a/api/context/context_logger_test.go
+++ b/api/context/context_logger_test.go
@@ -1,0 +1,93 @@
+package context
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+func BenchmarkStandardLog1(b *testing.B) {
+	benchmarkStandardLog(b, 1)
+}
+
+func BenchmarkStandardLog10(b *testing.B) {
+	benchmarkStandardLog(b, 10)
+}
+
+func BenchmarkStandardLog100(b *testing.B) {
+	benchmarkStandardLog(b, 100)
+}
+
+func BenchmarkStandardLog1000(b *testing.B) {
+	benchmarkStandardLog(b, 1000)
+}
+
+func benchmarkStandardLog(b *testing.B, f int) {
+	log.SetLevel(log.DebugLevel)
+	log.SetOutput(os.Stderr)
+	fields := log.Fields{
+		"time": time.Now().UTC().UnixNano() / int64(time.Millisecond),
+	}
+	for i := 0; i < f; i++ {
+		fields[fmt.Sprintf("key-%d", i)] = fmt.Sprintf("val-%d", i)
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		log.WithFields(fields).Debug("hi")
+	}
+}
+
+func BenchmarkContextLogDebug1(b *testing.B) {
+	benchmarkContextLog(b, 1, log.DebugLevel)
+}
+
+func BenchmarkContextLogDebug10(b *testing.B) {
+	benchmarkContextLog(b, 10, log.DebugLevel)
+}
+
+func BenchmarkContextLogDebug100(b *testing.B) {
+	benchmarkContextLog(b, 100, log.DebugLevel)
+}
+
+func BenchmarkContextLogDebug1000(b *testing.B) {
+	benchmarkContextLog(b, 1000, log.DebugLevel)
+}
+
+func BenchmarkContextLogError1(b *testing.B) {
+	benchmarkContextLog(b, 1, log.ErrorLevel)
+}
+
+func BenchmarkContextLogError10(b *testing.B) {
+	benchmarkContextLog(b, 10, log.ErrorLevel)
+}
+
+func BenchmarkContextLogError100(b *testing.B) {
+	benchmarkContextLog(b, 100, log.ErrorLevel)
+}
+
+func BenchmarkContextLogError1000(b *testing.B) {
+	benchmarkContextLog(b, 1000, log.ErrorLevel)
+}
+
+func benchmarkContextLog(b *testing.B, f int, lvl log.Level) {
+	log.SetLevel(lvl)
+	log.SetOutput(os.Stderr)
+	keys := make([]string, f)
+	vals := make([]string, f)
+	for i := 0; i < f; i++ {
+		keys[i] = fmt.Sprintf("key-%d", i)
+		vals[i] = fmt.Sprintf("val-%d", i)
+		RegisterCustomKey(keys[i], CustomLoggerKey)
+	}
+	ctx := Background()
+	for i := 0; i < f; i++ {
+		ctx = ctx.WithValue(keys[i], vals[i])
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		ctx.WithField("customField", "customValue").Debug("hi")
+	}
+}

--- a/api/context/context_test.go
+++ b/api/context/context_test.go
@@ -4,10 +4,12 @@ import (
 	"os"
 	"testing"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
+	log.SetLevel(log.ErrorLevel)
 	RegisterCustomKey(testLogKeyHello, CustomLoggerKey|CustomHeaderKey)
 	os.Exit(m.Run())
 }

--- a/api/types/types_context.go
+++ b/api/types/types_context.go
@@ -40,7 +40,7 @@ const (
 // Context is a libStorage context.
 type Context interface {
 	context.Context
-	log.FieldLogger
+	FieldLogger
 
 	// WithValue returns a copy of parent in which the value associated with
 	// key is val.

--- a/api/types/types_logger.go
+++ b/api/types/types_logger.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"github.com/Sirupsen/logrus"
+)
+
+// LogEntry is collected data to be emitted as a log entry.
+type LogEntry interface {
+	FieldLogger
+}
+
+// FieldLogger interface generalizes the Entry and Logger types
+type FieldLogger interface {
+	WithField(key string, value interface{}) LogEntry
+	WithFields(fields logrus.Fields) LogEntry
+	WithError(err error) LogEntry
+
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Printf(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Panicf(format string, args ...interface{})
+
+	Debug(args ...interface{})
+	Info(args ...interface{})
+	Print(args ...interface{})
+	Warn(args ...interface{})
+	Warning(args ...interface{})
+	Error(args ...interface{})
+	Fatal(args ...interface{})
+	Panic(args ...interface{})
+
+	Debugln(args ...interface{})
+	Infoln(args ...interface{})
+	Println(args ...interface{})
+	Warnln(args ...interface{})
+	Warningln(args ...interface{})
+	Errorln(args ...interface{})
+	Fatalln(args ...interface{})
+	Panicln(args ...interface{})
+}


### PR DESCRIPTION
This patch adds some benchmark tests to address the performance issue
related to the context logger. The follow command be used to execute
these benchmarks from the root of the project:

    $ go test -bench=. ./api/context 2> /dev/null
    PASS
    BenchmarkStandardLog1-8           300000          4970 ns/op
    BenchmarkStandardLog10-8          200000          8962 ns/op
    BenchmarkStandardLog100-8          30000         51700 ns/op
    BenchmarkStandardLog1000-8          3000        533795 ns/op
    BenchmarkContextLogDebug1-8       100000         16598 ns/op
    BenchmarkContextLogDebug10-8       30000         57492 ns/op
    BenchmarkContextLogDebug100-8       1000       1259054 ns/op
    BenchmarkContextLogDebug1000-8        20      87484041 ns/op
    BenchmarkContextLogError1-8      1000000          1074 ns/op
    BenchmarkContextLogError10-8     1000000          1086 ns/op
    BenchmarkContextLogError100-8    1000000          1104 ns/op
    BenchmarkContextLogError1000-8   1000000          1115 ns/op
    ok      github.com/emccode/libstorage/api/context   19.034s

Additionally, this patch also provides several optimizations to the
context logger logic in order to make it more efficient and improving
overall, general performance.