### PR TITLE
Task Service Memory Fix

### DIFF
--- a/api/server/router/snapshot/snapshot.go
+++ b/api/server/router/snapshot/snapshot.go
@@ -15,6 +15,7 @@ func init() {
 }
 
 type router struct {
+	config gofig.Config
 	routes []types.Route
 }
 
@@ -23,6 +24,7 @@ func (r *router) Name() string {
 }
 
 func (r *router) Init(config gofig.Config) {
+	r.config = config
 	r.initRoutes()
 }
 

--- a/api/server/router/snapshot/snapshot_routes.go
+++ b/api/server/router/snapshot/snapshot_routes.go
@@ -72,6 +72,7 @@ func (r *router) snapshots(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		services.TaskExecute(ctx, run, schema.ServiceSnapshotMapSchema),
@@ -105,6 +106,7 @@ func (r *router) snapshotsForService(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, schema.SnapshotMapSchema),
@@ -131,6 +133,7 @@ func (r *router) snapshotInspect(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, schema.SnapshotSchema),
@@ -157,6 +160,7 @@ func (r *router) snapshotRemove(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, nil),
@@ -206,6 +210,7 @@ func (r *router) volumeCreate(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, schema.VolumeSchema),
@@ -234,6 +239,7 @@ func (r *router) snapshotCopy(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, schema.SnapshotSchema),

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -77,6 +77,7 @@ func (r *router) volumes(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		services.TaskExecute(ctx, run, schema.ServiceVolumeMapSchema),
@@ -113,6 +114,7 @@ func (r *router) volumesForService(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, schema.VolumeMapSchema),
@@ -278,6 +280,7 @@ func (r *router) volumeInspect(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, schema.VolumeSchema),
@@ -326,6 +329,7 @@ func (r *router) volumeCreate(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, schema.VolumeSchema),
@@ -369,6 +373,7 @@ func (r *router) volumeCopy(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, schema.VolumeSchema),
@@ -396,6 +401,7 @@ func (r *router) volumeSnapshot(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, schema.SnapshotSchema),
@@ -448,6 +454,7 @@ func (r *router) volumeAttach(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, schema.VolumeAttachResponseSchema),
@@ -496,6 +503,7 @@ func (r *router) volumeDetach(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, nil),
@@ -593,6 +601,7 @@ func (r *router) volumeDetachAll(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		services.TaskExecute(ctx, run, schema.ServiceVolumeMapSchema),
@@ -657,6 +666,7 @@ func (r *router) volumeDetachAllForService(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, schema.VolumeMapSchema),
@@ -683,6 +693,7 @@ func (r *router) volumeRemove(
 
 	return httputils.WriteTask(
 		ctx,
+		r.config,
 		w,
 		store,
 		service.TaskExecute(ctx, run, nil),

--- a/api/types/types_config.go
+++ b/api/types/types_config.go
@@ -114,4 +114,13 @@ const (
 	// ConfigSchemaResponseValidationEnabled is a config key.
 	ConfigSchemaResponseValidationEnabled = ConfigRoot +
 		".schema.responseValidationEnabled"
+
+	// ConfigServerTasks is a config key.
+	ConfigServerTasks = ConfigServer + ".tasks"
+
+	// ConfigServerTasksExeTimeout is a config key.
+	ConfigServerTasksExeTimeout = ConfigServerTasks + ".exeTimeout"
+
+	// ConfigServerTasksLogTimeout is a config key.
+	ConfigServerTasksLogTimeout = ConfigServerTasks + ".logTimeout"
 )

--- a/imports/config/imports_config.go
+++ b/imports/config/imports_config.go
@@ -78,6 +78,8 @@ func init() {
 	rk(gofig.String, "30s", "", types.ConfigDeviceAttachTimeout)
 	rk(gofig.Int, 0, "", types.ConfigDeviceScanType)
 	rk(gofig.Bool, false, "", types.ConfigEmbedded)
+	rk(gofig.String, "1m", "", types.ConfigServerTasksExeTimeout)
+	rk(gofig.String, "0s", "", types.ConfigServerTasksLogTimeout)
 
 	gofig.Register(r)
 }


### PR DESCRIPTION
This patch addresses an issue with the task service keeping the results of operations with no expiration. Because the results are kept in memory, and because the internal implementation of a task includes references to the HTTP request object, the context, etc., hardly any memory is ever freed from a single API call. This results in the libStorage server consuming upwards of 50GB of RAM after several hours of constant usage.

This patch includes two, new configuration keys:

```yaml
libstorage:
  server:
    tasks:
      exeTimeout: 60s
      logTimeout: 0
```

The key `libstorage.server.tasks.exeTimeout` defaults to one minute, and it is the duration of time in which as task is expected to complete before being timed out and backgrounded, informing the user of the task ID that can be used to track the operation.

The second key, `libstorage.server.tasks.logTimeout` defaults to zero and is the duration of time for which a task is kept in memory after a task completes successfully or otherwise. This value should be increased to some positive duration if tasks often timeout and results need to be obtained after the fact on a regular basis.

Both property values are expected to be parsed by the [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) function. A duration can be `60s`, `1m`, `60000ms`, or even `1h`.

Many thanks to @cduchesne for discovering this issue.