### PR TITLE
Support for GoIsilon v1.1.0

### DIFF
--- a/drivers/storage/isilon/storage/isilon_storage.go
+++ b/drivers/storage/isilon/storage/isilon_storage.go
@@ -10,6 +10,7 @@ import (
 	"github.com/akutz/gofig"
 	"github.com/akutz/goof"
 	isi "github.com/emccode/goisilon"
+	isiv2 "github.com/emccode/goisilon/api/v2"
 
 	"github.com/emccode/libstorage/api/context"
 	"github.com/emccode/libstorage/api/registry"
@@ -63,7 +64,7 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 
 	var err error
 
-	if d.client, err = isi.NewClientWithArgs(
+	if d.client, err = isi.NewClientWithArgs(ctx,
 		d.endpoint(),
 		d.insecure(),
 		d.userName(),
@@ -169,7 +170,8 @@ func (d *driver) NextDeviceInfo(
 
 func (d *driver) getVolumeAttachments(ctx types.Context) (
 	[]*types.VolumeAttachment, error) {
-	exports, err := d.client.GetVolumeExports()
+
+	exports, err := d.getVolumeExports(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -248,29 +250,31 @@ func (d *driver) VolumeCreate(ctx types.Context, volumeName string,
 		return nil, goof.New("volume name already exists")
 	}
 
-	_, err = d.client.CreateVolume(volumeName)
+	_, err = d.client.CreateVolume(ctx, volumeName)
 	if err != nil {
-		return nil, goof.WithFieldE("volumeName", volumeName, "Error creating volume", err)
+		return nil, goof.WithFieldE(
+			"volumeName", volumeName, "Error creating volume", err)
 	}
 
 	// Set or update the quota for volume
 	if d.quotas() {
-		quota, err := d.client.GetQuota(volumeName)
+		quota, err := d.client.GetQuota(ctx, volumeName)
 		if quota == nil {
 			// PAPI uses bytes for it's size units, but REX-Ray uses gigs
-			err = d.client.SetQuotaSize(volumeName, *opts.Size*bytesPerGb)
+			err = d.client.SetQuotaSize(ctx, volumeName, *opts.Size*bytesPerGb)
 			if err != nil {
-				// TODO: not sure how to handle this situation.  Delete created volume
-				// and return an error?  Ignore and continue?
+				// TODO: not sure how to handle this situation. Delete created
+				// volume and return an error?  Ignore and continue?
 				return nil, goof.WithFieldE("volumeName", volumeName,
 					"Error creating volume", err)
 			}
 		} else {
 			// PAPI uses bytes for it's size units, but REX-Ray uses gigs
-			err = d.client.UpdateQuotaSize(volumeName, *opts.Size*bytesPerGb)
+			err = d.client.UpdateQuotaSize(
+				ctx, volumeName, *opts.Size*bytesPerGb)
 			if err != nil {
-				// TODO: not sure how to handle this situation.  Delete created volume
-				// and return an error?  Ignore and continue?
+				// TODO: not sure how to handle this situation. Delete created
+				// volume and return an error?  Ignore and continue?
 				return nil, goof.WithFieldE("volumeName", volumeName,
 					"Error creating volume", err)
 			}
@@ -288,13 +292,13 @@ func (d *driver) VolumeRemove(
 	opts types.Store) error {
 
 	if d.quotas() {
-		err := d.client.ClearQuota(volumeID)
+		err := d.client.ClearQuota(ctx, volumeID)
 		if err != nil {
 			return err
 		}
 	}
 
-	err := d.client.DeleteVolume(volumeID)
+	err := d.client.DeleteVolume(ctx, volumeID)
 	if err != nil {
 		return err
 	}
@@ -324,11 +328,13 @@ func (d *driver) VolumeAttach(
 	if vol == nil {
 		return nil, "", goof.New("no volumes returned")
 	}
-	if err := d.client.ExportVolume(volumeID); err != nil {
+
+	exportID, err := d.client.ExportVolume(ctx, volumeID)
+	if err != nil {
 		return nil, "", goof.WithError("problem exporting volume", err)
 	}
 	// see if anyone is attached already
-	clients, err := d.client.GetExportClients(volumeID)
+	clients, err := d.client.GetExportRootClientsByID(ctx, exportID)
 	if err != nil {
 		return nil, "", goof.WithError("problem getting export client", err)
 	}
@@ -352,10 +358,53 @@ func (d *driver) VolumeAttach(
 	}
 
 	log.WithField("clients", clients).Info("setting exports")
-	err = d.client.SetExportClients(volumeID, clients)
+	err = d.client.SetExportRootClientsByID(ctx, exportID, clients...)
 	if err != nil {
 		return nil, "", err
 	}
+
+	log.Info("mapping non-root users to root")
+	enabled := true
+	err = isiv2.ExportUpdate(ctx, d.client.API,
+		&isiv2.Export{
+			ID: exportID,
+			MapNonRoot: &isiv2.UserMapping{
+				Enabled: &enabled,
+				User: &isiv2.Persona{
+					ID: &isiv2.PersonaID{
+						ID:   "root",
+						Type: isiv2.PersonaIDTypeUser,
+					},
+				},
+			},
+		})
+	if err != nil {
+		return nil, "", err
+	}
+
+	log.Info("disabling root squash for export")
+	err = d.client.DisableRootMappingByID(ctx, exportID)
+	if err != nil {
+		return nil, "", err
+	}
+
+	/*log.Info("mapping root user to root")
+	err = isiv2.ExportUpdate(ctx, d.client.API,
+		&isiv2.Export{
+			ID: exportID,
+			MapRoot: &isiv2.UserMapping{
+				Enabled: &enabled,
+				User: &isiv2.Persona{
+					ID: &isiv2.PersonaID{
+						ID:   "root",
+						Type: isiv2.PersonaIDTypeUser,
+					},
+				},
+			},
+		})
+	if err != nil {
+		return nil, "", err
+	}*/
 
 	vol, err = d.VolumeInspect(ctx, volumeID,
 		&types.VolumeInspectOpts{Attachments: true})
@@ -392,7 +441,12 @@ func (d *driver) VolumeDetach(
 		return nil, err
 	}
 
-	clients, err := d.client.GetExportClients(volumeID)
+	export, err := d.client.GetExportByName(ctx, volumeID)
+	if err != nil {
+		return nil, goof.WithError("problem getting export", err)
+	}
+
+	clients, err := d.client.GetExportRootClientsByID(ctx, export.ID)
 	if err != nil {
 		return nil, goof.WithError("problem getting export client", err)
 	}
@@ -406,12 +460,12 @@ func (d *driver) VolumeDetach(
 
 	if len(newClients) > 0 {
 		log.WithField("clients", clients).Info("setting exports")
-		err = d.client.SetExportClients(volumeID, newClients)
+		err = d.client.SetExportRootClientsByID(ctx, export.ID, newClients...)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		if err := d.client.UnexportVolume(volumeID); err != nil {
+		if err := d.client.UnexportByID(ctx, export.ID); err != nil {
 			return nil, goof.WithError("problem unexporting volume", err)
 		}
 	}
@@ -484,8 +538,9 @@ func (d *driver) getVolume(ctx types.Context, volumeID, volumeName string,
 	attachments bool) ([]*types.Volume, error) {
 	var volumes []isi.Volume
 	if volumeID != "" || volumeName != "" {
-		volume, err := d.client.GetVolume(volumeID, volumeName)
-		if err != nil && !strings.Contains(err.Error(), "Unable to open object") {
+		volume, err := d.client.GetVolume(ctx, volumeID, volumeName)
+		if err != nil &&
+			!strings.Contains(err.Error(), "Unable to open object") {
 			return nil, err
 		}
 		if volume != nil {
@@ -493,7 +548,7 @@ func (d *driver) getVolume(ctx types.Context, volumeID, volumeName string,
 		}
 	} else {
 		var err error
-		volumes, err = d.client.GetVolumes()
+		volumes, err = d.client.GetVolumes(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -522,7 +577,7 @@ func (d *driver) getVolume(ctx types.Context, volumeID, volumeName string,
 
 	var volumesSD []*types.Volume
 	for _, volume := range volumes {
-		volSize, err := d.getSize(volume.Name, volume.Name)
+		volSize, err := d.getSize(ctx, volume.Name, volume.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -540,7 +595,9 @@ func (d *driver) getVolume(ctx types.Context, volumeID, volumeName string,
 	return volumesSD, nil
 }
 
-func (d *driver) getSize(volumeID, volumeName string) (int64, error) {
+func (d *driver) getSize(
+	ctx types.Context, volumeID, volumeName string) (int64, error) {
+
 	if d.quotas() == false {
 		return 0, nil
 	}
@@ -552,7 +609,7 @@ func (d *driver) getSize(volumeID, volumeName string) (int64, error) {
 		return 0, goof.New("volume name or ID not set")
 	}
 
-	quota, err := d.client.GetQuota(volumeName)
+	quota, err := d.client.GetQuota(ctx, volumeName)
 	if err != nil {
 		return 0, nil
 	}
@@ -563,6 +620,48 @@ func (d *driver) getSize(volumeID, volumeName string) (int64, error) {
 
 	return 0, nil
 
+}
+
+type isiVolExport struct {
+	Volume     isi.Volume
+	ExportPath string
+	Clients    []string
+}
+
+func (d *driver) getVolumeExports(ctx types.Context) ([]*isiVolExport, error) {
+
+	exports, err := d.client.GetExports(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	exportPaths := make(map[string]bool)
+	exportClients := make(map[string]([]string))
+	for _, export := range exports {
+		for _, path := range *export.Paths {
+			exportPaths[path] = true
+			exportClients[path] = *export.RootClients
+		}
+	}
+
+	volumes, err := d.client.GetVolumes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var volExports []*isiVolExport
+	for _, volume := range volumes {
+		vpath := d.client.API.VolumePath(volume.Name)
+		if _, ok := exportPaths[vpath]; ok {
+			volExports = append(volExports, &isiVolExport{
+				Volume:     volume,
+				ExportPath: vpath,
+				Clients:    exportClients[vpath],
+			})
+		}
+	}
+
+	return volExports, nil
 }
 
 func (d *driver) endpoint() string {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 794f4ee740f0eae62a42d92104f210d1a46f4727bbd4543fc3f41dde41fde517
-updated: 2016-07-01T13:54:05.201343222-07:00
+hash: 4586dcce2f277e39d8bbdc7e523c4638086f31adde64ba171fda3cecd6bb0313
+updated: 2016-08-26T13:41:25.423481906-05:00
 imports:
 - name: github.com/akutz/gofig
   version: 697c16916338166671910eeaccc50f21e3c10726
@@ -16,11 +16,33 @@ imports:
   - vboxwebsrv
   - virtualboxclient
 - name: github.com/asaskevich/govalidator
-  version: df81827fdd59d8b4fb93d8910b286ab7a3919520
+  version: 593d64559f7600f29581a3ee42177f5dbded27a9
 - name: github.com/aws/aws-sdk-go
   version: caee6e866bf437a6bef0777a3bf141cdd3aa022d
+  repo: https://github.com/aws/aws-sdk-go
+  subpackages:
+  - aws
+  - aws/awserr
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/ec2metadata
+  - aws/session
+  - service/efs
+  - aws/client
+  - aws/client/metadata
+  - aws/request
+  - aws/corehandlers
+  - aws/defaults
+  - private/endpoints
+  - aws/awsutil
+  - aws/signer/v4
+  - private/protocol
+  - private/protocol/restjson
+  - private/protocol/rest
+  - private/protocol/jsonrpc
+  - private/protocol/json/jsonutil
 - name: github.com/BurntSushi/toml
-  version: f0aeabca5a127c4078abb8c8d64298b147264b55
+  version: 99064174e013895bbd9b025c31100bd1d9b590ca
 - name: github.com/cesanta/ucl
   version: 97c016fce90e6af1b14558563ac46852167e6a76
 - name: github.com/cesanta/validate-json
@@ -32,36 +54,44 @@ imports:
   subpackages:
   - spew
 - name: github.com/emccode/goisilon
-  version: f9b53f0aaadb12a26b134830142fc537f492cb13
+  version: fad5453edf323030a20aad65cf85f3fbb0a3717f
   subpackages:
+  - api
   - api/v1
+  - api/v2
 - name: github.com/emccode/goscaleio
   version: 9d95003c0069b1949a0fb46832870799caa5c360
   repo: https://github.com/emccode/goscaleio
   subpackages:
   - types/v1
+- name: github.com/emccode/gournal
+  version: 8c5eb0ef035fa7a898a6017870e029f00578896f
+- name: github.com/go-ini/ini
+  version: a2610b3a793cfa7fdf0b07038068af5ddc12aba1
 - name: github.com/go-yaml/yaml
   version: b4a9f8c4b84c6c4256d669c649837f1441e4b050
   repo: https://github.com/akutz/yaml.git
 - name: github.com/gorilla/context
-  version: aed02d124ae4a0e94fea4541c8effd05bf0c8296
+  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: 9fa818a44c2bf1396a17f9d5a3c0f6dd39d2ff8e
+  version: 34bf6dc9faa08144e925df4fa1838551b16d6c2a
+- name: github.com/jmespath/go-jmespath
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/jteeuwen/go-bindata
   version: 1dd44b25b79c4d9060e582e90798e4d72537818c
   repo: https://github.com/akutz/go-bindata
 - name: github.com/kardianos/osext
-  version: 29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc
+  version: c2c54e542fb797ad986b31721e1baedf214ca413
   repo: https://github.com/kardianos/osext.git
   vcs: git
 - name: github.com/kr/pretty
-  version: add1dbc86daf0f983cd4a48ceb39deb95c729b67
+  version: cfb55aafdaf3ec08f0db22699ab822c50091b1c4
 - name: github.com/kr/text
   version: 7cafcd837844e784b526369c9bce262804aebc60
 - name: github.com/magiconair/properties
-  version: c265cfa48dda6474e208715ca93e987829f572f8
+  version: 61b492c03cf472e0c6419be5899b8e0dc28b1b88
 - name: github.com/mitchellh/mapstructure
-  version: d2dd0262208475919e1a362f675cfc0e7c10e905
+  version: ca63d7c062ee3c9f34db231e352b60012b4fd0c1
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -70,7 +100,7 @@ imports:
   version: 5f376aa629ac60c3215cc368e674bd996093a01a
   repo: https://github.com/akutz/logrus
 - name: github.com/spf13/cast
-  version: 27b586b42e29bec072fe7379259cc719e1289da6
+  version: e31f36ffc91a2ba9ddb72a4b6a607ff9b3d3cb63
 - name: github.com/spf13/jwalterweatherman
   version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
 - name: github.com/spf13/pflag
@@ -84,12 +114,12 @@ imports:
   subpackages:
   - assert
 - name: golang.org/x/net
-  version: b400c2eff1badec7022a8c8f5bea058b6315eed7
+  version: 6c89f9617983ee917132513a791d8b5850fe90c5
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/sys
-  version: 62bee037599929a6e9146f29d10dd5208c43507d
+  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
   subpackages:
   - unix
 - name: gopkg.in/fsnotify.v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,7 +34,7 @@ import:
 
 ### Isilon
   - package: github.com/emccode/goisilon
-    ref:     f9b53f0aaadb12a26b134830142fc537f492cb13
+    version: v1.1.0
 
 ### EFS
   - package: github.com/aws/aws-sdk-go


### PR DESCRIPTION
This patch adds support for the GoIsilon v1.1.0 release, enabling support for custom volume paths and enhanced NFS export security settings.

Note: This update does break backwards compatibility for the Isilon driver's `volumePath` configuration key. This key's value used to be appended to the base path `/ifs/volumes`, but that's no longer the case. The value of the `volumePath` key is now considered to be absolute. If it is not provided or empty, the value `/ifs/volumes` will be used. But if a value is specified for the key, that is the value used for the volume path, sans any prefix.

Related to #244, #245, #246.