### PR TITLE
EFS creation can fail if same volume name is used with different tag

### DIFF
--- a/drivers/storage/efs/storage/efs_storage.go
+++ b/drivers/storage/efs/storage/efs_storage.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"crypto/md5"
+	"fmt"
 	"strings"
 	"time"
 
@@ -226,8 +228,11 @@ func (d *driver) VolumeCreate(
 	name string,
 	opts *types.VolumeCreateOpts) (*types.Volume, error) {
 
+	// Token is limited to 64 ASCII characters so just create MD5 hash from full
+	// tag/name identifier
+	creationToken := fmt.Sprintf("%x", md5.Sum([]byte(d.getFullVolumeName(name))))
 	request := &awsefs.CreateFileSystemInput{
-		CreationToken:   aws.String(name),
+		CreationToken:   aws.String(creationToken),
 		PerformanceMode: aws.String(awsefs.PerformanceModeGeneralPurpose),
 	}
 	if opts.Type != nil && strings.ToLower(*opts.Type) == "maxio" {


### PR DESCRIPTION
Tested in AWS environment:

```
15:25:08 {efs_name *} ~/Workspace/go/src/github.com/emccode/libstorage » ./drivers/storage/efs/tests/test-env-up.sh acquia-grid
Environment launch started. It will take couple minutes to create whole environment...

15:35:31 {efs_name *} ~/Workspace/go/src/github.com/emccode/libstorage » GOOS=linux go test -cover -coverpkg 'github.com/emccode/libstorage/drivers/storage/efs,github.com/emccode/libstorage/drivers/storage/efs/executor,github.com/emccode/libstorage/drivers/storage/efs/sto
rage' -c -o drivers/storage/efs/tests/efs.test ./drivers/storage/efs/tests
warning: no packages being tested depend on github.com/emccode/libstorage/drivers/storage/efs
warning: no packages being tested depend on github.com/emccode/libstorage/drivers/storage/efs/executor
warning: no packages being tested depend on github.com/emccode/libstorage/drivers/storage/efs/storage

15:36:03 {efs_name *} ~/Workspace/go/src/github.com/emccode/libstorage » ./drivers/storage/efs/tests/test-run.sh ./drivers/storage/efs/tests/efs.test
Waiting for CF stack to come up ...
efs.test                                                                                                                                                                                                                                      100%   33MB   6.7MB/s   00:05
time="2016-09-08T13:36:20Z" level=info msg="making libStorage directory" mustPerm=false path="/home/ec2-user/.libstorage" perms=-rwxr-xr-x
time="2016-09-08T13:36:20Z" level=info msg="making libStorage directory" mustPerm=true path="/home/ec2-user/.libstorage/etc/libstorage" perms=-rwxr-xr-x
time="2016-09-08T13:36:20Z" level=info msg="making libStorage directory" mustPerm=true path="/home/ec2-user/.libstorage/var/lib/libstorage" perms=-rwxr-xr-x
time="2016-09-08T13:36:20Z" level=info msg="making libStorage directory" mustPerm=true path="/home/ec2-user/.libstorage/var/log/libstorage" perms=-rwxr-xr-x
time="2016-09-08T13:36:20Z" level=info msg="making libStorage directory" mustPerm=true path="/home/ec2-user/.libstorage/var/run/libstorage" perms=-rwxr-xr-x
PASS
coverage: 63.2% of statements in github.com/emccode/libstorage/drivers/storage/efs, github.com/emccode/libstorage/drivers/storage/efs/executor, github.com/emccode/libstorage/drivers/storage/efs/storage
efs.test.out                                                                                                                                                                                                                                  100%   16KB  16.3KB/s   00:00
Tests passed and coverge results are available at ./drivers/storage/efs/tests/efs.test.out
```