### PR TITLE
Fix to the VFS Test Issue

### DIFF
--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -380,12 +380,20 @@ func TestVolumeSnapshot(t *testing.T) {
 		assert.Equal(t, snapshotName, snap.Name)
 		assert.Equal(t, volumeID, snap.VolumeID)
 
-		snapshots, err := client.API().SnapshotsByService(nil, vfs.Name)
-		assert.NoError(t, err)
-		if err != nil {
-			t.FailNow()
+		snapCountEqual := false
+		for x := 0; x < 10; x++ {
+			time.Sleep(time.Duration(1) * time.Second)
+			snapshots, err := client.API().SnapshotsByService(nil, vfs.Name)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			if len(snapshots) != 10 {
+				continue
+			}
+			snapCountEqual = assert.EqualValues(t, 10, len(snapshots))
+			break
 		}
-		assert.EqualValues(t, 10, len(snapshots))
+		assert.True(t, snapCountEqual)
 	}
 	apitests.Run(t, vfs.Name, newTestConfig(t), tf)
 }


### PR DESCRIPTION
This patch should hopefully fix the VFS test issue where the underlying AUFS performance causes the TestVolumeSnapshot VFS test to fail. This change allows the point of failure to execute up to 10 times with a 1 second sleep period between each iteration. If at the end of 10 iterations it hasn't succeeded, the test will fail.