### PR TITLE
NextDevice Fix

### DIFF
--- a/cli/lsx/lsx.go
+++ b/cli/lsx/lsx.go
@@ -81,7 +81,7 @@ func Run() {
 	} else if cmd == "nextdevice" {
 		op = "next device"
 		opResult, opErr := d.NextDevice(ctx, store)
-		if opErr != nil {
+		if opErr != nil && opErr != apitypes.ErrNotImplemented {
 			err = opErr
 		} else {
 			result = opResult

--- a/drivers/storage/libstorage/libstorage_driver_funcs.go
+++ b/drivers/storage/libstorage/libstorage_driver_funcs.go
@@ -216,8 +216,18 @@ func (d *driver) VolumeAttach(
 		return nil, "", goof.New("missing service name")
 	}
 
+	nextDevice, err := d.NextDevice(ctx, utils.NewStore())
+	if err != nil {
+		return nil, "", err
+	}
+
+	var nextDevicePtr *string
+	if nextDevice != "" {
+		nextDevicePtr = &nextDevice
+	}
+
 	req := &types.VolumeAttachRequest{
-		NextDeviceName: opts.NextDevice,
+		NextDeviceName: nextDevicePtr,
 		Force:          opts.Force,
 		Opts:           opts.Opts.Map(),
 	}

--- a/drivers/storage/scaleio/executor/scaleio_executor.go
+++ b/drivers/storage/scaleio/executor/scaleio_executor.go
@@ -39,7 +39,7 @@ func (d *driver) Name() string {
 func (d *driver) NextDevice(
 	ctx types.Context,
 	opts types.Store) (string, error) {
-	return "", nil
+	return "", types.ErrNotImplemented
 }
 
 // LocalDevices returns a map of the system's local devices.

--- a/drivers/storage/vfs/storage/vfs_storage.go
+++ b/drivers/storage/vfs/storage/vfs_storage.go
@@ -338,7 +338,7 @@ func (d *driver) VolumeAttach(
 
 	vol.Attachments = []*types.VolumeAttachment{att}
 
-	return vol, "1234", nil
+	return vol, nextDevice, nil
 }
 
 func (d *driver) VolumeDetach(

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -459,7 +459,7 @@ func TestVolumeAttach(t *testing.T) {
 		if reply == nil {
 			t.FailNow()
 		}
-		assert.Equal(t, "1234", attTokn)
+		assert.Equal(t, "/dev/xvdc", attTokn)
 		assert.Equal(t, "vfs-002", reply.ID)
 		assert.Equal(t, "/dev/xvdc", reply.Attachments[0].DeviceName)
 


### PR DESCRIPTION
This patch fixes an issue where the NextDevice function of the Executor
was not being invoked prior to calling VolumeAttach. No value was being
provided in the VolumeAttachOpts.NextDevice field. Now the executor
should properly gather that information and provide it to the server in
the event of an attach call.