### PR TITLE
ebs: fix nil pointer deref on preempt

### DIFF
--- a/drivers/storage/ebs/storage/ebs_storage.go
+++ b/drivers/storage/ebs/storage/ebs_storage.go
@@ -537,15 +537,23 @@ func (d *driver) VolumeAttach(
 		return nil, "", goof.New("no volume found")
 	}
 	// Check if volume is already attached
-	if len(volumes[0].Attachments) > 0 && !opts.Force {
-		return nil, "", goof.New("volume already attached to a host")
-	}
-	// Detach already attached volume if forced
-	if opts.Force {
-		if _, err := d.VolumeDetach(ctx, volumeID, nil); err != nil {
+	if len(volumes[0].Attachments) > 0 {
+		// Detach already attached volume if forced
+		if !opts.Force {
+			return nil, "", goof.New("volume already attached to a host")
+		}
+		_, err := d.VolumeDetach(
+			ctx,
+			volumeID,
+			&types.VolumeDetachOpts{
+				Force: opts.Force,
+				Opts:  opts.Opts,
+			})
+		if err != nil {
 			return nil, "", goof.WithError("Error detaching volume", err)
 		}
 	}
+
 	// Retrieve next device name
 	nextDeviceName := ""
 	if opts.NextDevice != nil {


### PR DESCRIPTION
Saw this when using volume preemption during my testing:

```
# rexray volume mount --volumename travis_ebs_test
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x807218]

goroutine 25 [running]:
panic(0xd827a0, 0xc4200100d0)
       	/usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/emccode/rexray/vendor/github.com/emccode/libstorage/drivers/storage/ebs/storage.(*driver).VolumeDetach(0xc42015cea0, 0x14fe920, 0xc4202181e0, 0xc4202968e2, 0xc, 0x0, 0x1, 0xc420026860, 0x1)
       	/home/ubuntu/go/src/github.com/emccode/rexray/vendor/github.com/emccode/libstorage/drivers/storage/ebs/storage/ebs_storage.go:614 +0x2a8
github.com/emccode/rexray/vendor/github.com/emccode/libstorage/drivers/storage/ebs/storage.(*driver).VolumeAttach(0xc42015cea0, 0x14fe920, 0xc4202181e0, 0xc4202968e2, 0xc, 0xc4202c76e0, 0xc4202a9d88, 0x412fa8, 0x20, 0xe4be80, ...)
       	/home/ubuntu/go/src/github.com/emccode/rexray/vendor/github.com/emccode/libstorage/drivers/storage/ebs/storage/ebs_storage.go:545 +0x7a8
github.com/emccode/rexray/vendor/github.com/emccode/libstorage/api/registry.(*sdm).VolumeAttach(0xc4200c0340, 0x14fe920, 0xc4202181e0, 0xc4202968e2, 0xc, 0xc4202c76e0, 0xc4202a9df0, 0xc4204298f0, 0xc4203f28c0, 0x0, ...)
       	/home/ubuntu/go/src/github.com/emccode/rexray/vendor/github.com/emccode/libstorage/api/registry/registry_storage.go:119 +0xd1
github.com/emccode/rexray/vendor/github.com/emccode/libstorage/api/server/router/volume.(*router).volumeAttach.func1(0x14fe920, 0xc4202181e0, 0x14f87c0, 0xc4200f99c0, 0xc420463ff0, 0xc4201b8dc0, 0xefd295, 0xc)
       	/home/ubuntu/go/src/github.com/emccode/rexray/vendor/github.com/emccode/libstorage/api/server/router/volume/volume_routes.go:434 +0x1ee
github.com/emccode/rexray/vendor/github.com/emccode/libstorage/api/server/services.execTask(0xc4201ac300)
       	/home/ubuntu/go/src/github.com/emccode/rexray/vendor/github.com/emccode/libstorage/api/server/services/services_task.go:77 +0x732
github.com/emccode/rexray/vendor/github.com/emccode/libstorage/api/server/services.(*storageService).Init.func1(0xc4200f99c0)
       	/home/ubuntu/go/src/github.com/emccode/rexray/vendor/github.com/emccode/libstorage/api/server/services/services_storage.go:29 +0x73
created by github.com/emccode/rexray/vendor/github.com/emccode/libstorage/api/server/services.(*storageService).Init
       	/home/ubuntu/go/src/github.com/emccode/rexray/vendor/github.com/emccode/libstorage/api/server/services/services_storage.go:31 +0xc8
```

Problem stems from call to `VolumeDetach` from within `VolumeAttach` is always sending `nil` for for `types.VolumeDetachOpts`. So, just copy over the required fields.


As written, the old code would _always_ call `VolumeDetach` if preemption/Force was turned on -- even if the volume wasn't attached anywhere. Changed the logic to fix that as well, which eliminates an extra function call in that case.