### PR TITLE
Build libStorage with Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+lsx-*
+lss-*
 *.a
 *.d
 *.out


### PR DESCRIPTION
This patch adds the ability to build libStorage with Docker for Linux or Docker for Mac. To build libStorage with Docker, simply execute the following command:

```bash
$ make docker-build
```

The above command will copy the working source tree to a container named `build-libstorage`. If a container with that name does not exist, one is started using the "golang" image. If the container already exists then it is not created again. This enables delta builds -- updating only what has changed.

Upon a successful build the `lss-$GOOS` (libStorage development server) and  `lsx-$GOOS` (libStorage executor) are copied to the working directory.

There are also a few additional `docker-` targets, such as:

Target | Description
-------|------------
`docker-build` | Builds libStorage inside a Docker container.
`docker-test` | Executes all of the libStorage tests inside the container.
`docker-clean` | This target stops and removes the default container used for libStorage builds. The name of the default container is `build-libstorage`.
`docker-clobber` | This target stops and removes all Docker containers that have a name that matches the name of the configured container prefix (default prefix is `build-libstorage`).
`docker-list` | Lists all Docker containers that have a name that matches the name of the configured prefix (default prefix is `build-libstorage`).

Additionally, there are environment variables that can influence Docker builds:

Environment Variable | Description
----------------------|------------
`DBUILD_ONCE` |  When set to `1`, this environment variable instructs the Makefile to create a temporary, one-time use container for the subsequent build. The container is removed upon a successful build. If the build fails the container is not removed. This is because Makefile error logic is lacking. However, `make docker-clobber` can be used to easily clean up these containers. The containers will follow a given pattern using the container prefix (`build-libstorage` is the default prefix value). The one-time containers use `PREFIX-EPOCH`. For example, `build-libstorage-1474691232`.
`DGOOS` | This sets the OS target for which to build the libStorage binaries. Valid values are `linux` and `darwin`. If omitted the host OS value returned from `uname -s` is used instead.

# Cross-Compile Caveat
Please note that Darwin builds inside the container will not build the C bindings since Cgo for Darwin is not supported inside the container. In the future it may be possible with a custom container image that has the Darwin toolchain installed.