### PR TITLE
EBS Backward Compatibility Fix

### DIFF
--- a/drivers/storage/ebs/ebs_config_compat.go
+++ b/drivers/storage/ebs/ebs_config_compat.go
@@ -1,7 +1,9 @@
-package types
+package ebs
 
-import "github.com/akutz/gofig"
-import log "github.com/Sirupsen/logrus"
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/akutz/gofig"
+)
 
 const (
 	//ConfigEBS is a config key.

--- a/drivers/storage/ebs/executor/ebs_executor.go
+++ b/drivers/storage/ebs/executor/ebs_executor.go
@@ -10,7 +10,6 @@ import (
 	"github.com/akutz/gofig"
 	"github.com/akutz/goof"
 
-	ebsConfig "github.com/emccode/libstorage/api/drivers/storage/ebs"
 	"github.com/emccode/libstorage/api/registry"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/drivers/storage/ebs"
@@ -34,7 +33,7 @@ func newDriver() types.StorageExecutor {
 
 func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 	// Ensure backwards compatibility with ebs and ec2 in config
-	ebsConfig.BackCompat(config)
+	ebs.BackCompat(config)
 
 	d.config = config
 	// EBS suggests to use /dev/sd[f-p] for Linux EC2 instances.

--- a/drivers/storage/ebs/storage/ebs_storage.go
+++ b/drivers/storage/ebs/storage/ebs_storage.go
@@ -21,7 +21,6 @@ import (
 	awsec2 "github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/emccode/libstorage/api/context"
-	ebsConfig "github.com/emccode/libstorage/api/drivers/storage/ebs"
 	"github.com/emccode/libstorage/api/registry"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/drivers/storage/ebs"
@@ -78,7 +77,7 @@ func (d *driver) Name() string {
 // Init initializes the driver.
 func (d *driver) Init(context types.Context, config gofig.Config) error {
 	// Ensure backwards compatibility with ebs and ec2 in config
-	ebsConfig.BackCompat(config)
+	ebs.BackCompat(config)
 
 	d.config = config
 


### PR DESCRIPTION
This patch relocates the EBS back compat files to a location specific to the driver instead of in the core package area.