### PR TITLE
Storage Driver Sessions

### DIFF
--- a/api/context/context_keys.go
+++ b/api/context/context_keys.go
@@ -33,6 +33,9 @@ const (
 	// AdminTokenKey is the key for the server's admin token.
 	AdminTokenKey
 
+	// SessionKey is the key for the storage driver's session.
+	SessionKey
+
 	// keyLoggable is the minimum value from which the succeeding keys should
 	// be checked when logging.
 	keyLoggable

--- a/api/registry/registry.go
+++ b/api/registry/registry.go
@@ -133,7 +133,11 @@ func NewStorageDriver(name string) (types.StorageDriver, error) {
 		return nil, goof.WithField("driver", name, "invalid driver name")
 	}
 
-	return NewStorageDriverManager(ctor()), nil
+	sd := ctor()
+	if d, ok := sd.(types.StorageDriverWithLogin); ok {
+		return NewStorageDriverManagerWithLogin(d), nil
+	}
+	return NewStorageDriverManager(sd), nil
 }
 
 // NewOSDriver returns a new instance of the driver specified by the

--- a/api/registry/registry_storage.go
+++ b/api/registry/registry_storage.go
@@ -1,11 +1,14 @@
 package registry
 
-import (
-	"github.com/emccode/libstorage/api/types"
-)
+import "github.com/emccode/libstorage/api/types"
 
 type sdm struct {
 	types.StorageDriver
+	types.Context
+}
+
+type sdmWithLogin struct {
+	types.StorageDriverWithLogin
 	types.Context
 }
 
@@ -13,6 +16,12 @@ type sdm struct {
 func NewStorageDriverManager(
 	d types.StorageDriver) types.StorageDriver {
 	return &sdm{StorageDriver: d}
+}
+
+// NewStorageDriverManagerWithLogin returns a new storage driver manager.
+func NewStorageDriverManagerWithLogin(
+	d types.StorageDriverWithLogin) types.StorageDriverWithLogin {
+	return &sdmWithLogin{StorageDriverWithLogin: d}
 }
 
 func (d *sdm) API() types.APIClient {
@@ -161,4 +170,10 @@ func (d *sdm) SnapshotRemove(
 	opts types.Store) error {
 
 	return d.StorageDriver.SnapshotRemove(ctx.Join(d.Context), snapshotID, opts)
+}
+
+func (d *sdmWithLogin) Login(
+	ctx types.Context) (interface{}, error) {
+
+	return d.StorageDriverWithLogin.Login(ctx.Join(d.Context))
 }

--- a/api/server/handlers/handlers_storage_session.go
+++ b/api/server/handlers/handlers_storage_session.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/emccode/libstorage/api/context"
+	"github.com/emccode/libstorage/api/types"
+)
+
+// storageSessionHandler is an HTTP filter for ensuring that a storage session
+// is injected for routes that request it.
+type storageSessionHandler struct {
+	handler types.APIFunc
+}
+
+// NewStorageSessionHandler returns a new filter for ensuring that a storage
+// session is injected for routes that request it.
+func NewStorageSessionHandler() types.Middleware {
+	return &storageSessionHandler{}
+}
+
+func (h *storageSessionHandler) Name() string {
+	return "storage-session-handler"
+}
+
+func (h *storageSessionHandler) Handler(m types.APIFunc) types.APIFunc {
+	return (&storageSessionHandler{m}).Handle
+}
+
+// Handle is the type's Handler function.
+func (h *storageSessionHandler) Handle(
+	ctx types.Context,
+	w http.ResponseWriter,
+	req *http.Request,
+	store types.Store) error {
+
+	var err error
+	if ctx, err = context.WithStorageSession(ctx); err != nil {
+		return err
+	}
+	return h.handler(ctx, w, req, store)
+}

--- a/api/server/router/snapshot/snapshot.go
+++ b/api/server/router/snapshot/snapshot.go
@@ -53,6 +53,7 @@ func (r *router) initRoutes() {
 			"/snapshots/{service}",
 			r.snapshotsForService,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				nil, schema.SnapshotMapSchema, nil),
 		),
@@ -63,6 +64,7 @@ func (r *router) initRoutes() {
 			"/snapshots/{service}/{snapshotID}",
 			r.snapshotInspect,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(nil, schema.SnapshotSchema, nil),
 		),
 
@@ -74,6 +76,7 @@ func (r *router) initRoutes() {
 			"/snapshots/{service}/{snapshotID}",
 			r.volumeCreate,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeCreateRequestSchema,
 				schema.VolumeSchema,
@@ -87,6 +90,7 @@ func (r *router) initRoutes() {
 			"/snapshots/{service}/{snapshotID}",
 			r.snapshotCopy,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.SnapshotCopyRequestSchema,
 				schema.SnapshotSchema,
@@ -102,6 +106,7 @@ func (r *router) initRoutes() {
 			"/snapshots/{service}/{snapshotID}",
 			r.snapshotRemove,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 		),
 	}
 }

--- a/api/server/router/snapshot/snapshot_routes.go
+++ b/api/server/router/snapshot/snapshot_routes.go
@@ -32,6 +32,10 @@ func (r *router) snapshots(
 			svc types.StorageService) (interface{}, error) {
 
 			ctx = context.WithStorageService(ctx, svc)
+			var err error
+			if ctx, err = context.WithStorageSession(ctx); err != nil {
+				return nil, err
+			}
 
 			objs, err := svc.Driver().Snapshots(ctx, store)
 			if err != nil {

--- a/api/server/router/volume/volume.go
+++ b/api/server/router/volume/volume.go
@@ -65,6 +65,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}",
 			r.volumesForService,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(nil, schema.VolumeMapSchema, nil),
 		),
 
@@ -74,6 +75,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}/{volumeID}",
 			r.volumeInspect,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(nil, schema.VolumeSchema, nil),
 		),
 
@@ -85,6 +87,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}",
 			r.volumeDetachAllForService,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeDetachRequestSchema,
 				schema.VolumeMapSchema,
@@ -98,6 +101,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}",
 			r.volumeCreate,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeCreateRequestSchema,
 				schema.VolumeSchema,
@@ -111,6 +115,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}/{volumeID}",
 			r.volumeCopy,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeCopyRequestSchema,
 				schema.VolumeSchema,
@@ -124,6 +129,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}/{volumeID}",
 			r.volumeSnapshot,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeSnapshotRequestSchema,
 				schema.SnapshotSchema,
@@ -137,6 +143,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}/{volumeID}",
 			r.volumeAttach,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeAttachRequestSchema,
 				schema.VolumeSchema,
@@ -162,6 +169,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}/{volumeID}",
 			r.volumeDetach,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeDetachRequestSchema,
 				schema.VolumeSchema,
@@ -175,6 +183,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}/{volumeID}",
 			r.volumeRemove,
 			handlers.NewServiceValidator(),
+			handlers.NewStorageSessionHandler(),
 		),
 	}
 }

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -47,6 +47,12 @@ func (r *router) volumes(
 			svc types.StorageService) (interface{}, error) {
 
 			ctx = context.WithStorageService(ctx, svc)
+
+			var err error
+			if ctx, err = context.WithStorageSession(ctx); err != nil {
+				return nil, err
+			}
+
 			return getFilteredVolumes(ctx, req, store, svc, opts, filter)
 		}
 
@@ -532,8 +538,14 @@ func (r *router) volumeDetachAll(
 			svc types.StorageService) (interface{}, error) {
 
 			ctx = context.WithStorageService(ctx, svc)
+
 			if _, ok := context.InstanceID(ctx); !ok {
 				return nil, utils.NewMissingInstanceIDError(service.Name())
+			}
+
+			var err error
+			if ctx, err = context.WithStorageSession(ctx); err != nil {
+				return nil, err
 			}
 
 			driver := svc.Driver()

--- a/api/types/types_drivers_storage.go
+++ b/api/types/types_drivers_storage.go
@@ -155,3 +155,13 @@ type StorageDriver interface {
 		snapshotID string,
 		opts Store) error
 }
+
+// StorageDriverWithLogin is a StorageDriver with a Login function.
+type StorageDriverWithLogin interface {
+	StorageDriver
+
+	// Login creates a new connection to the storage platform for the provided
+	// context.
+	Login(
+		ctx Context) (interface{}, error)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 9bf64d1ef1d1dc736991d9e54e5e77dbfdfd5dcb44ce79433c82232c20bf7e87
-updated: 2016-09-27T18:38:40.712760622-05:00
+updated: 2016-09-28T14:15:52.550869408-05:00
 imports:
 - name: github.com/akutz/gofig
   version: 697c16916338166671910eeaccc50f21e3c10726


### PR DESCRIPTION
This patch puts in place a new piece of core framework, a new interface named `StorageDriverWithLogin` that defines a single function, `Login(context.Context) (interface{}, error)`. Types that implement the existing `StorageDriver` interface may now also implement the `StorageDriverWithLogin` interface by defining the new `Login` function. Now part of the core workflow, the `Login` function is invoked for all HTTP routes that consume a configured storage service and grant the underlying storage driver implementation the ability to set a login session object on the context of the current HTTP request.