### PR TITLE
InstanceID Fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
   - make gometalinter-all
   - make -j build
   - make -j test
+  - VFS_INSTANCEID_USE_FIELDS=true ./drivers/storage/vfs/tests/vfs.test
 
 after_success:
   - make -j cover

--- a/api/types/types_instanceid_test.go
+++ b/api/types/types_instanceid_test.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	metadataBase64       = "eyJIZWxsbyI6ImhpIiwiVGhlcmUiOiJoZXJlIiwiVmFsdWUiOjMsIkRhdGEiOnsiZjEiOjAsImYyIjoiMSJ9fQ=="
-	expectedI1String     = "vfs=1234," + metadataBase64
-	expectedI1NoIDString = "vfs=," + metadataBase64
+	expectedI1String     = "vfs=1234,," + metadataBase64
+	expectedI1NoIDString = "vfs=,," + metadataBase64
 )
 
 func newMetadataCtor(
@@ -53,10 +53,21 @@ func TestInstanceIDMarshalText(t *testing.T) {
 	i3 := &InstanceID{}
 	assert.NoError(t, i3.UnmarshalText([]byte(expectedI1String)))
 	assert.EqualValues(t, i1, i3)
+
+	i4 := &InstanceID{
+		ID:     "1234",
+		Driver: "vfs",
+		Fields: map[string]string{"region": "west"},
+	}
+	assert.Equal(t, "vfs=1234,region=west", i4.String())
 }
 
 func TestInstanceIDMarshalJSON(t *testing.T) {
-	i1 := &InstanceID{ID: "1234", Driver: "vfs"}
+	i1 := &InstanceID{
+		ID:     "1234",
+		Driver: "vfs",
+		Fields: map[string]string{"region": "west"},
+	}
 	i1.MarshalMetadata(newMetadata())
 
 	buf, err := i1.MarshalJSON()

--- a/drivers/storage/libstorage/libstorage_client_xcli.go
+++ b/drivers/storage/libstorage/libstorage_client_xcli.go
@@ -53,16 +53,20 @@ func (c *client) InstanceID(
 
 	ctx = ctx.WithValue(context.InstanceIDKey, iid)
 
-	ctx.Debug("sending instanceID in API.InstanceInspect call")
-	instance, err := c.InstanceInspect(ctx, serviceName)
-	if err != nil {
-		return nil, err
+	if iid.HasMetadata() {
+		ctx.Debug("sending instanceID in API.InstanceInspect call")
+		instance, err := c.InstanceInspect(ctx, serviceName)
+		if err != nil {
+			return nil, err
+		}
+		ctx.Debug("received instanceID from API.InstanceInspect call")
+		iid.ID = instance.InstanceID.ID
+		iid.Fields = instance.InstanceID.Fields
+		iid.DeleteMetadata()
 	}
 
-	iid.ID = instance.InstanceID.ID
-	iid.DeleteMetadata()
 	c.instanceIDCache.Set(serviceName, iid)
-	ctx.Debug("received instanceID from API.InstanceInspect call")
+	ctx.Debug("cached instanceID")
 
 	ctx.Debug("xli instanceID success")
 	return iid, nil

--- a/drivers/storage/vfs/executor/vfs_executor.go
+++ b/drivers/storage/vfs/executor/vfs_executor.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"strconv"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
@@ -65,17 +66,21 @@ func (d *driver) InstanceID(
 	ctx types.Context,
 	opts types.Store) (*types.InstanceID, error) {
 
+	iid := &types.InstanceID{Driver: vfs.Name}
 	hostName, err := utils.HostName()
 	if err != nil {
 		return nil, err
 	}
 
-	iid := &types.InstanceID{Driver: vfs.Name}
+	if ok, _ := strconv.ParseBool(os.Getenv("VFS_INSTANCEID_USE_FIELDS")); ok {
+		iid.ID = hostName
+		iid.Fields = map[string]string{"region": "east"}
+		return iid, nil
+	}
 
 	if err := iid.MarshalMetadata(hostName); err != nil {
 		return nil, err
 	}
-
 	return iid, nil
 }
 

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -715,7 +716,11 @@ func instanceID() (*types.InstanceID, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &types.InstanceID{ID: hostName, Driver: vfs.Name}, nil
+	iid := &types.InstanceID{ID: hostName, Driver: vfs.Name}
+	if ok, _ := strconv.ParseBool(os.Getenv("VFS_INSTANCEID_USE_FIELDS")); ok {
+		iid.Fields = map[string]string{"region": "east"}
+	}
+	return iid, nil
 }
 
 func assertVolDir(


### PR DESCRIPTION
This patch adjusts the core framework's definition of the `InstanceID` type as well as how `InstanceID` objects are consumed and used. The  `InstanceID` type now contains a field named `Fields` with a type of `map[string]string`. The `Fields` map may be leveraged by storage  executors to transport storage-platform specific information along  with the `InstanceID` object.

An `InstanceID` object still maintains the notion of metadata, but  the new `Fields` map is permanently associated with an `InstanceID` object whereas metadata is set to nil once used by the remote  `InstanceInspect` API call. In fact, it is now permissible for executor implementations to directly set an `InstanceID` object's `ID` and/or `Fields` data, omitting the metadata entirely. If an `InstanceID` object is without metadata the remote `InstanceInspect` API call is not invoked in order to transform the metadata into the actual instance identifier.

For executor implementations that are able to gather the complete  instance identifier from a client it is now more efficient for this process to be used than relying on a remote API call to `InstanceInspect` in order to transform an `InstanceID` object.
