### PR TITLE
EBS Request Scoped Connections; Zone Filtering

### DIFF
--- a/drivers/storage/ebs/ebs.go
+++ b/drivers/storage/ebs/ebs.go
@@ -16,6 +16,14 @@ const (
 
 	// DefaultMaxRetries is the max number of times to retry failed operations
 	DefaultMaxRetries = 10
+
+	// InstanceIDFieldRegion is the key to retrieve the region value from the
+	// InstanceID Field map.
+	InstanceIDFieldRegion = "region"
+
+	// InstanceIDFieldAvailabilityZone is the key to retrieve the availability
+	// zone value from the InstanceID Field map.
+	InstanceIDFieldAvailabilityZone = "availabilityZone"
 )
 
 func init() {

--- a/drivers/storage/ebs/executor/ebs_executor.go
+++ b/drivers/storage/ebs/executor/ebs_executor.go
@@ -2,9 +2,10 @@ package executor
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
-	"io/ioutil"
-	"net/http"
+	"os"
+	"path"
 	"regexp"
 	"strings"
 
@@ -14,78 +15,48 @@ import (
 	"github.com/emccode/libstorage/api/registry"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/drivers/storage/ebs"
+	ebsUtils "github.com/emccode/libstorage/drivers/storage/ebs/utils"
 )
 
 // driver is the storage executor for the ec2 storage driver.
 type driver struct {
-	config         gofig.Config
-	nextDeviceInfo *types.NextDeviceInfo
+	name   string
+	config gofig.Config
 }
 
 func init() {
 	registry.RegisterStorageExecutor(ebs.Name, newDriver)
-	// Backwards compatibility for ec2 executor
-	registry.RegisterStorageExecutor(ebs.OldName, newDriver)
+	// backwards compatibility for ec2 executor
+	registry.RegisterStorageExecutor(ebs.OldName, newOldDriver)
 }
 
 func newDriver() types.StorageExecutor {
-	return &driver{}
+	return &driver{name: ebs.Name}
+}
+
+func newOldDriver() types.StorageExecutor {
+	return &driver{name: ebs.OldName}
 }
 
 func (d *driver) Init(ctx types.Context, config gofig.Config) error {
-	// Ensure backwards compatibility with ebs and ec2 in config
+	// ensure backwards compatibility with ebs and ec2 in config
 	ebs.BackCompat(config)
-
 	d.config = config
-	// EBS suggests to use /dev/sd[f-p] for Linux EC2 instances.
-	// Also on Linux EC2 instances, although the device path may show up
-	// as /dev/sd* on the EC2 side, it will appear locally as /dev/xvd*
-	d.nextDeviceInfo = &types.NextDeviceInfo{
-		Prefix:  "xvd",
-		Pattern: "[f-p]",
-		Ignore:  false,
-	}
-
 	return nil
 }
 
 func (d *driver) Name() string {
-	return ebs.Name
+	return d.name
 }
-
-// InstanceID returns the local instance ID for the test
-func InstanceID() (*types.InstanceID, error) {
-	return newDriver().InstanceID(nil, nil)
-}
-
-const (
-	iidURL = "http://169.254.169.254/latest/meta-data/instance-id/"
-)
 
 // InstanceID returns the instance ID from the current instance from metadata
 func (d *driver) InstanceID(
 	ctx types.Context,
 	opts types.Store) (*types.InstanceID, error) {
-	// Retrieve instance ID from metadata
-	res, err := http.Get(iidURL)
-	if err != nil {
-		return nil, goof.WithError("ec2 instance id lookup failed", err)
-	}
-	instanceID, err := ioutil.ReadAll(res.Body)
-	res.Body.Close()
-	if err != nil {
-		return nil, goof.WithError("error reading ec2 instance id", err)
-	}
-
-	iid := &types.InstanceID{Driver: d.Name()}
-	if err := iid.MarshalMetadata(string(instanceID)); err != nil {
-		return nil, goof.WithError("error marshalling instance id", err)
-	}
-
-	return iid, nil
+	return ebsUtils.InstanceID(ctx)
 }
 
-var errNoAvaiDevice = goof.New("No available device")
+var errNoAvaiDevice = goof.New("no available device")
 
 // NextDevice returns the next available device.
 func (d *driver) NextDevice(
@@ -107,8 +78,8 @@ func (d *driver) NextDevice(
 
 	for localDevice := range localDeviceMapping {
 		re, _ := regexp.Compile(`^/dev/` +
-			d.nextDeviceInfo.Prefix +
-			`(` + d.nextDeviceInfo.Pattern + `)`)
+			ebsUtils.NextDeviceInfo.Prefix +
+			`(` + ebsUtils.NextDeviceInfo.Pattern + `)`)
 		res := re.FindStringSubmatch(localDevice)
 		if len(res) > 0 {
 			localDeviceNames[res[1]] = true
@@ -116,15 +87,15 @@ func (d *driver) NextDevice(
 	}
 
 	// Find which letters are used for ephemeral devices
-	ephemeralDevices, err := d.getEphemeralDevices()
+	ephemeralDevices, err := d.getEphemeralDevices(ctx)
 	if err != nil {
 		return "", goof.WithError("error getting ephemeral devices", err)
 	}
 
 	for _, ephemeralDevice := range ephemeralDevices {
 		re, _ := regexp.Compile(`^` +
-			d.nextDeviceInfo.Prefix +
-			`(` + d.nextDeviceInfo.Pattern + `)`)
+			ebsUtils.NextDeviceInfo.Prefix +
+			`(` + ebsUtils.NextDeviceInfo.Pattern + `)`)
 		res := re.FindStringSubmatch(ephemeralDevice)
 		if len(res) > 0 {
 			localDeviceNames[res[1]] = true
@@ -133,92 +104,89 @@ func (d *driver) NextDevice(
 
 	// Find next available letter for device path
 	for _, letter := range letters {
-		if !localDeviceNames[letter] {
-			nextDeviceName := "/dev/" +
-				d.nextDeviceInfo.Prefix + letter
-			return nextDeviceName, nil
+		if localDeviceNames[letter] {
+			continue
 		}
+		return fmt.Sprintf(
+			"/dev/%s%s", ebsUtils.NextDeviceInfo.Prefix, letter), nil
 	}
 	return "", errNoAvaiDevice
 }
+
+const procPartitions = "/proc/partitions"
+
+var xvdRX = regexp.MustCompile(`^xvd[a-z]$`)
 
 // Retrieve device paths currently attached and/or mounted
 func (d *driver) LocalDevices(
 	ctx types.Context,
 	opts *types.LocalDevicesOpts) (*types.LocalDevices, error) {
-	// Read from /proc/partitions
-	localDevices := make(map[string]string)
-	file := "/proc/partitions"
-	contentBytes, err := ioutil.ReadFile(file)
+
+	f, err := os.Open(procPartitions)
 	if err != nil {
-		return nil, goof.WithError(
-			"error reading /proc/partitions", err)
+		return nil, goof.WithError("error reading "+procPartitions, err)
 	}
+	defer f.Close()
 
-	content := string(contentBytes)
+	devMap := map[string]string{}
 
-	// Parse device names
-	var deviceName string
-	lines := strings.Split(content, "\n")
-	for _, line := range lines[2:] {
-		fields := strings.Fields(line)
-		if len(fields) == 4 {
-			deviceName = "/dev/" + fields[3]
-			// Device ID is also device path for EBS, since it
-			// can be obtained both locally and remotely
-			// (remotely being from the AWS API side)
-			localDevices[deviceName] = deviceName
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 4 {
+			continue
 		}
+		devName := fields[3]
+		if !xvdRX.MatchString(devName) {
+			continue
+		}
+		devPath := path.Join("/dev/", devName)
+		devMap[devPath] = devPath
 	}
 
-	return &types.LocalDevices{
-		Driver:    d.Name(),
-		DeviceMap: localDevices,
-	}, nil
+	ld := &types.LocalDevices{Driver: d.Name()}
+	if len(devMap) > 0 {
+		ld.DeviceMap = devMap
+	}
 
+	return ld, nil
 }
 
-const bdmURL = "http://169.254.169.254/latest/meta-data/block-device-mapping/"
+var ephemDevRX = regexp.MustCompile(`ephemeral([0-9]|1[0-9]|2[0-3])$`)
 
 // Find ephemeral devices from metadata
-func (d *driver) getEphemeralDevices() (deviceNames []string, err error) {
-	// Get list of all block devices
-	res, err := http.Get(bdmURL)
+func (d *driver) getEphemeralDevices(
+	ctx types.Context) (deviceNames []string, err error) {
+
+	buf, err := ebsUtils.BlockDevices(ctx)
 	if err != nil {
-		return nil, goof.WithError("ec2 block device mapping lookup failed", err)
-	}
-	blockDeviceMappings, err := ioutil.ReadAll(res.Body)
-	res.Body.Close()
-	if err != nil {
-		return nil, goof.WithError("error reading ec2 block device mappings", err)
+		return nil, err
 	}
 
 	// Filter list of all block devices for ephemeral devices
-	re, _ := regexp.Compile(`ephemeral([0-9]|1[0-9]|2[0-3])$`)
-
-	scanner := bufio.NewScanner(strings.NewReader(string(blockDeviceMappings)))
+	scanner := bufio.NewScanner(bytes.NewReader(buf))
 	scanner.Split(bufio.ScanWords)
 
-	var input string
 	for scanner.Scan() {
-		input = scanner.Text()
-		if re.MatchString(input) {
-			// Find device name for ephemeral device
-			res, err := http.Get(fmt.Sprintf("%s%s", bdmURL, input))
-			if err != nil {
-				return nil, goof.WithError("ec2 block device mapping lookup failed", err)
-			}
-			deviceName, err := ioutil.ReadAll(res.Body)
-			// Compensate for kernel volume mapping i.e. change "/dev/sda" to "/dev/xvda"
-			deviceNameStr := strings.Replace(string(deviceName), "sd", d.nextDeviceInfo.Prefix, 1)
-			res.Body.Close()
-			if err != nil {
-				return nil, goof.WithError("error reading ec2 block device mappings", err)
-			}
-
-			deviceNames = append(deviceNames, deviceNameStr)
+		word := scanner.Bytes()
+		if !ephemDevRX.Match(word) {
+			continue
 		}
-	}
 
+		name, err := ebsUtils.BlockDeviceName(ctx, string(word))
+		if err != nil {
+			return nil, goof.WithError(
+				"ec2 block device mapping lookup failed", err)
+		}
+
+		// compensate for kernel volume mapping i.e. change "/dev/sda" to
+		// "/dev/xvda"
+		deviceNameStr := strings.Replace(
+			string(name),
+			"sd",
+			ebsUtils.NextDeviceInfo.Prefix, 1)
+
+		deviceNames = append(deviceNames, deviceNameStr)
+	}
 	return deviceNames, nil
 }

--- a/drivers/storage/ebs/tests/ebs_test.go
+++ b/drivers/storage/ebs/tests/ebs_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/api/utils"
 	"github.com/emccode/libstorage/drivers/storage/ebs"
-	ec2x "github.com/emccode/libstorage/drivers/storage/ebs/executor"
+	ebsUtils "github.com/emccode/libstorage/drivers/storage/ebs/utils"
 )
 
 // Put contents of sample config.yml here
@@ -102,7 +102,7 @@ func TestInstanceID(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Get Instance ID metadata from executor
-	iid, err := ec2x.InstanceID()
+	iid, err := ebsUtils.InstanceID(ctx)
 	assert.NoError(t, err)
 	if err != nil {
 		t.Fatal(err)
@@ -146,7 +146,7 @@ func TestInstanceIDEC2(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Get Instance ID metadata from executor
-	iid, err := ec2x.InstanceID()
+	iid, err := ebsUtils.InstanceID(ctx)
 	assert.NoError(t, err)
 	if err != nil {
 		t.Fatal(err)

--- a/drivers/storage/ebs/utils/utils.go
+++ b/drivers/storage/ebs/utils/utils.go
@@ -1,0 +1,101 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/emccode/libstorage/api/types"
+	"github.com/emccode/libstorage/drivers/storage/ebs"
+)
+
+const (
+	raddr  = "169.254.169.254"
+	iidURL = "http://" + raddr + "/latest/dynamic/instance-identity/document"
+	bdmURL = "http://" + raddr + "/latest/meta-data/block-device-mapping/"
+)
+
+type instanceIdentityDoc struct {
+	InstanceID       string `json:"instanceId,omitempty"`
+	Region           string `json:"region,omitempty"`
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
+}
+
+// InstanceID returns the instance ID for the local host.
+func InstanceID(ctx types.Context) (*types.InstanceID, error) {
+	req, err := http.NewRequest(http.MethodGet, iidURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	iid := instanceIdentityDoc{}
+	dec := json.NewDecoder(res.Body)
+	if err := dec.Decode(&iid); err != nil {
+		return nil, err
+	}
+
+	return &types.InstanceID{
+		ID:     iid.InstanceID,
+		Driver: ebs.Name,
+		Fields: map[string]string{
+			ebs.InstanceIDFieldRegion:           iid.Region,
+			ebs.InstanceIDFieldAvailabilityZone: iid.AvailabilityZone,
+		},
+	}, nil
+}
+
+// BlockDevices returns the EBS devices attached to the local host.
+func BlockDevices(ctx types.Context) ([]byte, error) {
+
+	req, err := http.NewRequest(http.MethodGet, bdmURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	buf, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+// BlockDeviceName returns the name of the provided EBS device.
+func BlockDeviceName(
+	ctx types.Context,
+	device string) ([]byte, error) {
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		fmt.Sprintf("%s%s", bdmURL, device),
+		nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	buf, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}

--- a/drivers/storage/ebs/utils/utils_go17.go
+++ b/drivers/storage/ebs/utils/utils_go17.go
@@ -1,0 +1,14 @@
+// +build go1.7
+
+package utils
+
+import (
+	"net/http"
+
+	"github.com/emccode/libstorage/api/types"
+)
+
+func doRequest(ctx types.Context, req *http.Request) (*http.Response, error) {
+	req = req.WithContext(ctx)
+	return http.DefaultClient.Do(req)
+}

--- a/drivers/storage/ebs/utils/utils_pre_go17.go
+++ b/drivers/storage/ebs/utils/utils_pre_go17.go
@@ -1,0 +1,15 @@
+// +build !go1.7
+
+package utils
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context/ctxhttp"
+
+	"github.com/emccode/libstorage/api/types"
+)
+
+func doRequest(ctx types.Context, req *http.Request) (*http.Response, error) {
+	return ctxhttp.Do(ctx, http.DefaultClient, req)
+}

--- a/drivers/storage/ebs/utils/utils_test.go
+++ b/drivers/storage/ebs/utils/utils_test.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/emccode/libstorage/api/context"
+)
+
+func skipTest(t *testing.T) {
+	if ok, _ := strconv.ParseBool(os.Getenv("EBS_UTILS_TEST")); !ok {
+		t.Skip()
+	}
+}
+
+func TestInstanceID(t *testing.T) {
+	skipTest(t)
+	iid, err := InstanceID(context.Background())
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	t.Logf("instanceID=%s", iid.String())
+}

--- a/drivers/storage/ebs/utils/utils_unix.go
+++ b/drivers/storage/ebs/utils/utils_unix.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package utils
+
+import (
+	"github.com/emccode/libstorage/api/types"
+)
+
+// NextDeviceInfo is the NextDeviceInfo object for EBS.
+//
+// EBS suggests to use /dev/sd[f-p] for Linux EC2 instances. Also on Linux EC2
+// instances, although the device path may show up as /dev/sd* on the EC2 side,
+// it will appear locally as /dev/xvd*
+var NextDeviceInfo = &types.NextDeviceInfo{
+	Prefix:  "xvd",
+	Pattern: "[f-p]",
+	Ignore:  false,
+}


### PR DESCRIPTION
This patch updates the EBS driver to establish AWS API connections based on the instance information per request, available through the request context. Additionally, volume describe operations sent to the AWS API will now be filtered based on the availability zone of the originating client.