### PR TITLE
EBS Session Caching

### DIFF
--- a/drivers/storage/ebs/ebs.go
+++ b/drivers/storage/ebs/ebs.go
@@ -24,6 +24,24 @@ const (
 	// InstanceIDFieldAvailabilityZone is the key to retrieve the availability
 	// zone value from the InstanceID Field map.
 	InstanceIDFieldAvailabilityZone = "availabilityZone"
+
+	// AccessKey is a key constant.
+	AccessKey = "accessKey"
+
+	// SecretKey is a key constant.
+	SecretKey = "secretKey"
+
+	// Region is a key constant.
+	Region = "region"
+
+	// Endpoint is a key constant.
+	Endpoint = "endpoint"
+
+	// MaxRetries is a key constant.
+	MaxRetries = "maxRetries"
+
+	// Tag is a key constant.
+	Tag = "tag"
 )
 
 func init() {
@@ -32,17 +50,17 @@ func init() {
 
 func registerConfig() {
 	r := gofig.NewRegistration("EBS")
-	r.Key(gofig.String, "", "", "", "ebs.accessKey")
-	r.Key(gofig.String, "", "", "", "ebs.secretKey")
-	r.Key(gofig.String, "", "", "", "ebs.region")
-	r.Key(gofig.String, "", "", "", "ebs.endpoint")
-	r.Key(gofig.Int, "", DefaultMaxRetries, "", "ebs.maxRetries")
-	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", "ebs.tag")
-	r.Key(gofig.String, "", "", "", "ec2.accessKey")
-	r.Key(gofig.String, "", "", "", "ec2.secretKey")
-	r.Key(gofig.String, "", "", "", "ec2.region")
-	r.Key(gofig.String, "", "", "", "ec2.endpoint")
-	r.Key(gofig.Int, "", DefaultMaxRetries, "", "ec2.maxRetries")
-	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", "ec2.tag")
+	r.Key(gofig.String, "", "", "", Name+"."+AccessKey)
+	r.Key(gofig.String, "", "", "", Name+"."+SecretKey)
+	r.Key(gofig.String, "", "", "", Name+"."+Region)
+	r.Key(gofig.String, "", "", "", Name+"."+Endpoint)
+	r.Key(gofig.Int, "", DefaultMaxRetries, "", Name+"."+MaxRetries)
+	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", Name+"."+Tag)
+	r.Key(gofig.String, "", "", "", OldName+"."+AccessKey)
+	r.Key(gofig.String, "", "", "", OldName+"."+SecretKey)
+	r.Key(gofig.String, "", "", "", OldName+"."+Region)
+	r.Key(gofig.String, "", "", "", OldName+"."+Endpoint)
+	r.Key(gofig.Int, "", DefaultMaxRetries, "", OldName+"."+MaxRetries)
+	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", OldName+"."+Tag)
 	gofig.Register(r)
 }

--- a/drivers/storage/ebs/ebs_config_compat.go
+++ b/drivers/storage/ebs/ebs_config_compat.go
@@ -10,22 +10,22 @@ const (
 	ConfigEBS = "ebs"
 
 	//ConfigEBSAccessKey is a config key.
-	ConfigEBSAccessKey = ConfigEBS + ".accessKey"
+	ConfigEBSAccessKey = ConfigEBS + "." + AccessKey
 
 	//ConfigEBSSecretKey is a config key.
-	ConfigEBSSecretKey = ConfigEBS + ".secretKey"
+	ConfigEBSSecretKey = ConfigEBS + "." + SecretKey
 
 	//ConfigEBSRegion is a config key.
-	ConfigEBSRegion = ConfigEBS + ".region"
+	ConfigEBSRegion = ConfigEBS + "." + Region
 
 	//ConfigEBSEndpoint is a config key.
-	ConfigEBSEndpoint = ConfigEBS + ".endpoint"
+	ConfigEBSEndpoint = ConfigEBS + "." + Endpoint
 
 	//ConfigEBSMaxRetries is a config key.
-	ConfigEBSMaxRetries = ConfigEBS + ".maxRetries"
+	ConfigEBSMaxRetries = ConfigEBS + "." + MaxRetries
 
 	//ConfigEBSTag is a config key.
-	ConfigEBSTag = ConfigEBS + ".tag"
+	ConfigEBSTag = ConfigEBS + "." + Tag
 
 	//ConfigEBSRexrayTag is a config key.
 	ConfigEBSRexrayTag = ConfigEBS + ".rexrayTag"
@@ -34,22 +34,22 @@ const (
 	ConfigOldEBS = "ec2"
 
 	//ConfigOldEBSAccessKey is a config key.
-	ConfigOldEBSAccessKey = ConfigOldEBS + ".accessKey"
+	ConfigOldEBSAccessKey = ConfigOldEBS + "." + AccessKey
 
 	//ConfigOldEBSSecretKey is a config key.
-	ConfigOldEBSSecretKey = ConfigOldEBS + ".secretKey"
+	ConfigOldEBSSecretKey = ConfigOldEBS + "." + SecretKey
 
 	//ConfigOldEBSRegion is a config key.
-	ConfigOldEBSRegion = ConfigOldEBS + ".region"
+	ConfigOldEBSRegion = ConfigOldEBS + "." + Region
 
 	//ConfigOldEBSEndpoint is a config key.
-	ConfigOldEBSEndpoint = ConfigOldEBS + ".endpoint"
+	ConfigOldEBSEndpoint = ConfigOldEBS + "." + Endpoint
 
 	//ConfigOldEBSMaxRetries is a config key.
-	ConfigOldEBSMaxRetries = ConfigOldEBS + ".maxRetries"
+	ConfigOldEBSMaxRetries = ConfigOldEBS + "." + MaxRetries
 
 	//ConfigOldEBSTag is a config key.
-	ConfigOldEBSTag = ConfigOldEBS + ".tag"
+	ConfigOldEBSTag = ConfigOldEBS + "." + Tag
 
 	//ConfigOldEBSRexrayTag is a config key.
 	ConfigOldEBSRexrayTag = ConfigOldEBS + ".rexrayTag"


### PR DESCRIPTION
This patch introduces EBS session caching. Now that EBS sessions are scoped to HTTP requests and shuttled around with the Context object, it becomes necessary to optimize their usage. Session objects are now cached using a key that is the MD5 checksum of the concatenation of the following string values that are identifying characteristics of an EBS session: 

* region
* endpoint
* access key

Any unique combination of the above values (including if one is absent) will produce a unique session object that is then cached for future use, available to requests with the same identifying characteristics for establishing an EBS session.