### PR TITLE
EBS Storage Driver Instance Fix

### DIFF
--- a/drivers/storage/ebs/storage/ebs_storage.go
+++ b/drivers/storage/ebs/storage/ebs_storage.go
@@ -224,7 +224,13 @@ func (d *driver) InstanceInspect(
 	ctx types.Context,
 	opts types.Store) (*types.Instance, error) {
 
-	return nil, types.ErrNotImplemented
+	iid := context.MustInstanceID(ctx)
+	return &types.Instance{
+		Name:         iid.ID,
+		Region:       iid.Fields[ebs.InstanceIDFieldRegion],
+		InstanceID:   iid,
+		ProviderName: iid.Driver,
+	}, nil
 }
 
 // Volumes returns all volumes or a filtered list of volumes.


### PR DESCRIPTION
This patch reimplements the EBS storage driver's Instance function so that it returns the data from the context's InstanceID.