### PR TITLE
Fix for Executor when Not Implemented

### DIFF
--- a/api/types/types_errors.go
+++ b/api/types/types_errors.go
@@ -8,6 +8,9 @@ import (
 // a function is not implemented.
 var ErrNotImplemented = goof.New("not implemented")
 
+// ErrTimedOut is the error that is used to indicate an operation timed out.
+var ErrTimedOut = goof.New("timed out")
+
 // ErrUnsupportedForClientType is the error that occurs when an operation is
 // invoked that is unsupported for the current client type.
 type ErrUnsupportedForClientType struct{ goof.Goof }

--- a/drivers/storage/ebs/executor/ebs_executor.go
+++ b/drivers/storage/ebs/executor/ebs_executor.go
@@ -49,6 +49,16 @@ func (d *driver) Name() string {
 	return d.name
 }
 
+// Supported returns a flag indicating whether or not the platform
+// implementing the executor is valid for the host on which the executor
+// resides.
+func (d *driver) Supported(
+	ctx types.Context,
+	opts types.Store) (bool, error) {
+
+	return ebsUtils.IsEC2Instance(ctx)
+}
+
 // InstanceID returns the instance ID from the current instance from metadata
 func (d *driver) InstanceID(
 	ctx types.Context,

--- a/drivers/storage/ebs/utils/utils_go17.go
+++ b/drivers/storage/ebs/utils/utils_go17.go
@@ -9,6 +9,13 @@ import (
 )
 
 func doRequest(ctx types.Context, req *http.Request) (*http.Response, error) {
+	return doRequestWithClient(ctx, http.DefaultClient, req)
+}
+
+func doRequestWithClient(
+	ctx types.Context,
+	client *http.Client,
+	req *http.Request) (*http.Response, error) {
 	req = req.WithContext(ctx)
-	return http.DefaultClient.Do(req)
+	return client.Do(req)
 }

--- a/drivers/storage/ebs/utils/utils_pre_go17.go
+++ b/drivers/storage/ebs/utils/utils_pre_go17.go
@@ -11,5 +11,12 @@ import (
 )
 
 func doRequest(ctx types.Context, req *http.Request) (*http.Response, error) {
-	return ctxhttp.Do(ctx, http.DefaultClient, req)
+	return doRequestWithClient(ctx, http.DefaultClient, req)
+}
+
+func doRequestWithClient(
+	ctx types.Context,
+	client *http.Client,
+	req *http.Request) (*http.Response, error) {
+	return ctxhttp.Do(ctx, client, req)
 }

--- a/drivers/storage/libstorage/libstorage_driver.go
+++ b/drivers/storage/libstorage/libstorage_driver.go
@@ -106,6 +106,7 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 		}
 
 		d.lsxCache = &lss{Store: utils.NewStore()}
+		d.supportedCache = utils.NewStore()
 		d.instanceIDCache = &lss{Store: newIIDCache()}
 	}
 

--- a/drivers/storage/libstorage/libstorage_store.go
+++ b/drivers/storage/libstorage/libstorage_store.go
@@ -20,16 +20,6 @@ func (s *lss) GetExecutorInfo(lsx string) *types.ExecutorInfo {
 	return nil
 }
 
-func (s *lss) GetInstanceID(service string) *types.InstanceID {
-	if obj, ok := s.Get(service).(*types.InstanceID); ok {
-		return obj
-	}
-	return nil
-}
-
-func (s *lss) GetLocalDevices(service string) map[string]string {
-	if obj, ok := s.Get(service).(map[string]string); ok {
-		return obj
-	}
-	return nil
+func (s *lss) GetInstanceID(driverName string) *types.InstanceID {
+	return s.Store.GetInstanceID(driverName)
 }

--- a/drivers/storage/vfs/executor/vfs_executor.go
+++ b/drivers/storage/vfs/executor/vfs_executor.go
@@ -42,6 +42,13 @@ func (d *driver) Name() string {
 	return vfs.Name
 }
 
+func (d *driver) Supported(
+	ctx types.Context,
+	opts types.Store) (bool, error) {
+
+	return true, nil
+}
+
 func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 	d.config = config
 


### PR DESCRIPTION
This patch should provide a means for a platform's executor code to indicate that a function is not implemented on a given system. This way the libStorage client may check for the "not implemented" error upon initialization and not fail to start if one of storage platforms available on a remote libStorage service is invalid for the current client.

For example, if a remote libStorage server is configured with three services -- two for EBS and one for ScaleIO -- and a client that *only* supports EBS accesses the libStorage server, the client would fail upon initialization. This is because the client scans the server to determine what services (and their drivers) are configured and upon initialization attempts the discovery of the remotely configured platform's instance information locally through the use of the storage executor binary. Well, just because the remote libStorage server has a ScaleIO service, not all clients are required to support that. Yet all clients would see that service and attempt to discover their ScaleIO instance information. 

Now executor implementations have the ability to determine if they are supported on a given client and return "not implemented" (`types.ErrNotImplemented`) if they are not. This error will not cause the client to fail, but rather simply emit a message to the log indicating that it occurred.