### PR TITLE
isilon: add Supported() to executor

### DIFF
--- a/drivers/storage/isilon/executor/isilon_executor.go
+++ b/drivers/storage/isilon/executor/isilon_executor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/akutz/gofig"
 	"github.com/akutz/goof"
+	"github.com/akutz/gotil"
 
 	"github.com/emccode/libstorage/api/registry"
 	"github.com/emccode/libstorage/api/types"
@@ -41,6 +42,11 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 
 func (d *driver) Name() string {
 	return isilon.Name
+}
+
+func (d *driver) Supported(ctx types.Context, opts types.Store) (bool, error) {
+	// make sure NFS mounts can be done
+	return gotil.FileExistsInPath("mount.nfs"), nil
 }
 
 // InstanceID returns the local instance ID for the test


### PR DESCRIPTION
Isilon clients NFS mount the volumes, so make sure that mount.nfs
is present.

FWIW, I was hesitant to implement this way, as it is Linux specific. At first I was just going to check if `/usr/sbin/mount.nfs` existed, but that could be distro specific. But the executor already parses files in `/proc`, which binds it to Linux. So I'm not adding any new restrictions.

Also, it seemed possible that a client could by using NFSv4, and if they were they would need `mount.nfs4`, but the Linux driver actually doesn't use `mount -t nfs` or `mount -t nfs4`, it just calls `mount`, and can't be overriden, so this is also not a current issue. It merely relies on the presence of a `:` in the device to infer it is NFS.

This was inspired by #296 