### PR TITLE
Enable Executor Supported func for EFS

### DIFF
--- a/drivers/storage/efs/efs.go
+++ b/drivers/storage/efs/efs.go
@@ -7,6 +7,14 @@ import (
 const (
 	// Name is the provider's name.
 	Name = "efs"
+
+	// InstanceIDFieldRegion is the key to retrieve the region value from the
+	// InstanceID Field map.
+	InstanceIDFieldRegion = "region"
+
+	// InstanceIDFieldAvailabilityZone is the key to retrieve the availability
+	// zone value from the InstanceID Field map.
+	InstanceIDFieldAvailabilityZone = "availabilityZone"
 )
 
 func init() {

--- a/drivers/storage/efs/executor/efs_executor.go
+++ b/drivers/storage/efs/executor/efs_executor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/emccode/libstorage/api/registry"
 	"github.com/emccode/libstorage/api/types"
 	"github.com/emccode/libstorage/drivers/storage/efs"
+	efsUtils "github.com/emccode/libstorage/drivers/storage/efs/utils"
 )
 
 // driver is the storage executor for the efs storage driver.
@@ -45,6 +46,16 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 
 func (d *driver) Name() string {
 	return efs.Name
+}
+
+// Supported returns a flag indicating whether or not the platform
+// implementing the executor is valid for the host on which the executor
+// resides.
+func (d *driver) Supported(
+	ctx types.Context,
+	opts types.Store) (bool, error) {
+
+	return efsUtils.IsEC2Instance(ctx)
 }
 
 // InstanceID returns the local instance ID for the test

--- a/drivers/storage/efs/utils/utils.go
+++ b/drivers/storage/efs/utils/utils.go
@@ -1,0 +1,73 @@
+package utils
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/emccode/libstorage/api/types"
+	"github.com/emccode/libstorage/drivers/storage/efs"
+)
+
+const (
+	raddr  = "169.254.169.254"
+	mdtURL = "http://" + raddr + "/latest/meta-data/"
+	iidURL = "http://" + raddr + "/latest/dynamic/instance-identity/document"
+)
+
+// IsEC2Instance returns a flag indicating whether the executing host is an EC2
+// instance based on whether or not the metadata URL can be accessed.
+func IsEC2Instance(ctx types.Context) (bool, error) {
+	client := &http.Client{Timeout: time.Duration(1 * time.Second)}
+	req, err := http.NewRequest(http.MethodHead, mdtURL, nil)
+	if err != nil {
+		return false, err
+	}
+	res, err := doRequestWithClient(ctx, client, req)
+	if err != nil {
+		if terr, ok := err.(net.Error); ok && terr.Timeout() {
+			return false, nil
+		}
+		return false, err
+	}
+	if res.StatusCode >= 200 || res.StatusCode <= 299 {
+		return true, nil
+	}
+	return false, nil
+}
+
+type instanceIdentityDoc struct {
+	InstanceID       string `json:"instanceId,omitempty"`
+	Region           string `json:"region,omitempty"`
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
+}
+
+// InstanceID returns the instance ID for the local host.
+func InstanceID(ctx types.Context) (*types.InstanceID, error) {
+	req, err := http.NewRequest(http.MethodGet, iidURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	iid := instanceIdentityDoc{}
+	dec := json.NewDecoder(res.Body)
+	if err := dec.Decode(&iid); err != nil {
+		return nil, err
+	}
+
+	return &types.InstanceID{
+		ID:     iid.InstanceID,
+		Driver: efs.Name,
+		Fields: map[string]string{
+			efs.InstanceIDFieldRegion:           iid.Region,
+			efs.InstanceIDFieldAvailabilityZone: iid.AvailabilityZone,
+		},
+	}, nil
+}

--- a/drivers/storage/efs/utils/utils_go17.go
+++ b/drivers/storage/efs/utils/utils_go17.go
@@ -1,0 +1,21 @@
+// +build go1.7
+
+package utils
+
+import (
+	"net/http"
+
+	"github.com/emccode/libstorage/api/types"
+)
+
+func doRequest(ctx types.Context, req *http.Request) (*http.Response, error) {
+	return doRequestWithClient(ctx, http.DefaultClient, req)
+}
+
+func doRequestWithClient(
+	ctx types.Context,
+	client *http.Client,
+	req *http.Request) (*http.Response, error) {
+	req = req.WithContext(ctx)
+	return client.Do(req)
+}

--- a/drivers/storage/efs/utils/utils_pre_go17.go
+++ b/drivers/storage/efs/utils/utils_pre_go17.go
@@ -1,0 +1,22 @@
+// +build !go1.7
+
+package utils
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context/ctxhttp"
+
+	"github.com/emccode/libstorage/api/types"
+)
+
+func doRequest(ctx types.Context, req *http.Request) (*http.Response, error) {
+	return doRequestWithClient(ctx, http.DefaultClient, req)
+}
+
+func doRequestWithClient(
+	ctx types.Context,
+	client *http.Client,
+	req *http.Request) (*http.Response, error) {
+	return ctxhttp.Do(ctx, client, req)
+}


### PR DESCRIPTION
This patch adds support for the executor's "supported" command to the EFS executor implementation.